### PR TITLE
Feat: Add Experiment Execution and Analytics Services (Completes #5)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -170,6 +170,12 @@
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>${jacoco-maven-plugin.version}</version>
+				<configuration>
+					<excludes>
+						<!-- Exclude Spring Boot main application class (no business logic) -->
+						<exclude>com/locallab/LocalLabApplication.class</exclude>
+					</excludes>
+				</configuration>
 				<executions>
 					<!-- Prepare agent for test coverage -->
 					<execution>

--- a/backend/src/main/java/com/locallab/config/AsyncConfig.java
+++ b/backend/src/main/java/com/locallab/config/AsyncConfig.java
@@ -1,0 +1,53 @@
+package com.locallab.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * Configuration for asynchronous task execution.
+ *
+ * <p>This configuration enables Spring's async processing capability, which is required for
+ * executing experiments in background threads. The executor is configured with sensible defaults
+ * for local LLM experimentation workloads.
+ *
+ * <h3>Executor Configuration:</h3>
+ *
+ * <ul>
+ *   <li><strong>Core Pool Size:</strong> 2 threads - experiments are resource-intensive
+ *   <li><strong>Max Pool Size:</strong> 4 threads - allows some concurrency whilst respecting local
+ *       resources
+ *   <li><strong>Queue Capacity:</strong> 10 - limits pending experiments
+ *   <li><strong>Thread Name Prefix:</strong> "experiment-exec-" for easy identification in logs
+ * </ul>
+ *
+ * @author William Stephen
+ * @see com.locallab.service.ExperimentExecutorService
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    /**
+     * Creates the task executor for async experiment execution.
+     *
+     * <p>The executor is configured conservatively since LLM inference is resource-intensive and
+     * typically runs on local hardware. This prevents overloading the system with too many
+     * concurrent experiments.
+     *
+     * @return the configured task executor
+     */
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("experiment-exec-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/src/main/java/com/locallab/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/locallab/config/WebSocketConfig.java
@@ -1,0 +1,80 @@
+package com.locallab.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * Configuration for WebSocket messaging with STOMP protocol.
+ *
+ * <p>This configuration enables WebSocket communication using the STOMP sub-protocol, which
+ * provides a messaging layer over WebSocket connections. It configures the message broker for
+ * publishing experiment progress updates to subscribed clients.
+ *
+ * <h3>Endpoints:</h3>
+ *
+ * <ul>
+ *   <li>{@code /ws} - WebSocket connection endpoint. Clients connect here using SockJS.
+ * </ul>
+ *
+ * <h3>Topic Destinations:</h3>
+ *
+ * <ul>
+ *   <li>{@code /topic/experiments/{id}/progress} - Subscribe for experiment progress updates
+ * </ul>
+ *
+ * <h3>Example Client Usage (JavaScript):</h3>
+ *
+ * <pre>{@code
+ * const socket = new SockJS('/ws');
+ * const stompClient = Stomp.over(socket);
+ *
+ * stompClient.connect({}, function(frame) {
+ *     stompClient.subscribe('/topic/experiments/1/progress', function(message) {
+ *         const data = JSON.parse(message.body);
+ *         console.log('Progress:', data.type, data.payload);
+ *     });
+ * });
+ * }</pre>
+ *
+ * @author William Stephen
+ * @see com.locallab.dto.WebSocketMessage
+ * @see com.locallab.service.ExperimentExecutorService
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    /**
+     * Configures the message broker for handling WebSocket messages.
+     *
+     * <p>Sets up a simple in-memory message broker with the {@code /topic} prefix for
+     * broadcast-style messaging. Application destination prefix is set to {@code /app} for
+     * client-to-server messages (though not used in current implementation).
+     *
+     * @param registry the message broker registry to configure
+     */
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+
+    /**
+     * Registers the STOMP endpoint for WebSocket connections.
+     *
+     * <p>Configures the {@code /ws} endpoint with SockJS fallback support for browsers that don't
+     * support WebSocket natively. Allows connections from the configured origins (localhost:5173
+     * for development).
+     *
+     * @param registry the STOMP endpoint registry to configure
+     */
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("http://localhost:5173", "http://127.0.0.1:5173")
+                .withSockJS();
+    }
+}

--- a/backend/src/main/java/com/locallab/dto/ExperimentConfig.java
+++ b/backend/src/main/java/com/locallab/dto/ExperimentConfig.java
@@ -1,0 +1,141 @@
+package com.locallab.dto;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO representing the configuration for an experiment.
+ *
+ * <p>Contains all settings required to execute an experiment, including model selection, embedding
+ * models for RAG, iteration count, context mode, and hyperparameters. This configuration determines
+ * the run matrix for the experiment.
+ *
+ * <p>The total number of experiment runs is calculated as: {@code models.size() ×
+ * max(embeddingModels.size(), 1) × iterations}
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * ExperimentConfig config = ExperimentConfig.builder()
+ *     .models(List.of("qwen2.5-coder:7b", "codellama:7b"))
+ *     .embeddingModels(List.of("nomic-embed-text"))
+ *     .iterations(3)
+ *     .contextMode("RAG")
+ *     .documentId(1L)
+ *     .hyperparameters(Hyperparameters.builder()
+ *         .temperature(0.7)
+ *         .topP(0.9)
+ *         .build())
+ *     .build();
+ * }</pre>
+ *
+ * <h3>Context Modes:</h3>
+ *
+ * <ul>
+ *   <li><strong>NONE:</strong> No additional context; prompt only
+ *   <li><strong>RAG:</strong> Retrieval-augmented generation using document chunks
+ *   <li><strong>FULL_CONTEXT:</strong> Complete context provided inline
+ * </ul>
+ *
+ * @author William Stephen
+ * @see com.locallab.dto.request.ExperimentRequest
+ * @see Hyperparameters
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentConfig {
+
+    /**
+     * List of model names to test in the experiment.
+     *
+     * <p>Each model will be run with all combinations of embedding models and iterations. At least
+     * one model must be specified.
+     *
+     * <p>Example: {@code ["qwen2.5-coder:7b", "codellama:7b", "deepseek-coder:6.7b"]}
+     */
+    @NotEmpty(message = "At least one model must be selected")
+    private List<String> models;
+
+    /**
+     * List of embedding model names for RAG-based experiments.
+     *
+     * <p>Required when contextMode is RAG. Each embedding model will be tested with all model and
+     * iteration combinations. If not provided or empty, non-RAG mode is assumed.
+     *
+     * <p>Example: {@code ["nomic-embed-text", "mxbai-embed-large"]}
+     */
+    private List<String> embeddingModels;
+
+    /**
+     * Number of iterations to run for each model/embedding combination.
+     *
+     * <p>Multiple iterations allow for statistical analysis of model performance variance. Must be
+     * at least 1 and at most 100.
+     */
+    @NotNull(message = "Iterations must be specified")
+    @Min(value = 1, message = "Iterations must be at least 1")
+    @Max(value = 100, message = "Iterations must not exceed 100")
+    private Integer iterations;
+
+    /**
+     * Determines how context is provided to the model.
+     *
+     * <p>Valid values are:
+     *
+     * <ul>
+     *   <li>NONE - No additional context
+     *   <li>RAG - Retrieval-augmented generation from a document
+     *   <li>FULL_CONTEXT - Complete context provided inline
+     * </ul>
+     */
+    @NotNull(message = "Context mode must be specified")
+    private String contextMode;
+
+    /**
+     * ID of the document to use for RAG-based experiments.
+     *
+     * <p>Required when contextMode is RAG. References a document that has been uploaded and
+     * processed for vector retrieval.
+     */
+    private Long documentId;
+
+    /**
+     * ID of the system prompt to use for all runs.
+     *
+     * <p>Optional. If specified, references a saved SystemPrompt that will be used consistently
+     * across all experiment runs.
+     */
+    private Long systemPromptId;
+
+    /**
+     * Hyperparameters controlling model generation behaviour.
+     *
+     * <p>Contains settings such as temperature, top-p, top-k, context window size, and maximum
+     * token limits. Validated according to Hyperparameters constraints.
+     */
+    @NotNull(message = "Hyperparameters must be specified")
+    @Valid
+    private Hyperparameters hyperparameters;
+
+    /**
+     * Variable values to substitute into the task template prompt.
+     *
+     * <p>Keys correspond to variable placeholders in the format {@code {{variableName}}} within the
+     * task template's prompt. Values are substituted at execution time.
+     *
+     * <p>Example: {@code {"code": "function example() { ... }", "language": "JavaScript"}}
+     */
+    private Map<String, String> variableValues;
+}

--- a/backend/src/main/java/com/locallab/dto/ExperimentExecutionState.java
+++ b/backend/src/main/java/com/locallab/dto/ExperimentExecutionState.java
@@ -1,0 +1,90 @@
+package com.locallab.dto;
+
+import lombok.Data;
+
+/**
+ * Represents the runtime state of an executing experiment.
+ *
+ * <p>This class tracks the execution state of an experiment, including progress and control flags
+ * for pause/cancel operations. It uses volatile fields to ensure thread-safe visibility across the
+ * main executor thread and control threads.
+ *
+ * <h3>Thread Safety:</h3>
+ *
+ * <p>The {@code paused} and {@code cancelled} flags are marked as volatile to ensure proper
+ * visibility when set by a control thread and read by the executor thread. The {@code
+ * completedRuns} field is also volatile as it's updated during execution and read by progress
+ * reporting.
+ *
+ * <h3>Example Usage:</h3>
+ *
+ * <pre>{@code
+ * ExperimentExecutionState state = new ExperimentExecutionState(experimentId);
+ * state.setTotalRuns(12);
+ *
+ * // During execution
+ * state.setCompletedRuns(state.getCompletedRuns() + 1);
+ *
+ * // From control thread
+ * state.setPaused(true);
+ * }</pre>
+ *
+ * @author William Stephen
+ * @see com.locallab.service.ExperimentExecutorService
+ */
+@Data
+public class ExperimentExecutionState {
+
+    /**
+     * The identifier of the experiment being executed.
+     *
+     * <p>This is immutable after construction as it identifies the experiment throughout its
+     * execution lifecycle.
+     */
+    private final Long experimentId;
+
+    /**
+     * Flag indicating whether the experiment is paused.
+     *
+     * <p>When set to true, the executor will stop processing after the current run completes and
+     * update the experiment status to PAUSED. Marked as volatile for thread-safe visibility.
+     */
+    private volatile boolean paused;
+
+    /**
+     * Flag indicating whether the experiment has been cancelled.
+     *
+     * <p>When set to true, the executor will stop processing after the current run completes and
+     * update the experiment status to FAILED. Marked as volatile for thread-safe visibility.
+     */
+    private volatile boolean cancelled;
+
+    /**
+     * The number of runs that have completed (successfully or with failure).
+     *
+     * <p>Updated after each run finishes. Used for progress calculation. Marked as volatile for
+     * thread-safe visibility.
+     */
+    private volatile int completedRuns;
+
+    /**
+     * The total number of runs to be executed.
+     *
+     * <p>Calculated from the run configuration matrix (models x embeddings x iterations). Set once
+     * at the start of execution.
+     */
+    private int totalRuns;
+
+    /**
+     * Constructs a new execution state for the specified experiment.
+     *
+     * @param experimentId the identifier of the experiment to track
+     */
+    public ExperimentExecutionState(Long experimentId) {
+        this.experimentId = experimentId;
+        this.paused = false;
+        this.cancelled = false;
+        this.completedRuns = 0;
+        this.totalRuns = 0;
+    }
+}

--- a/backend/src/main/java/com/locallab/dto/ExperimentProgress.java
+++ b/backend/src/main/java/com/locallab/dto/ExperimentProgress.java
@@ -1,0 +1,68 @@
+package com.locallab.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO representing the progress of an experiment execution.
+ *
+ * <p>This class provides real-time progress information for an executing experiment, including the
+ * number of completed runs, total runs, and calculated percentage completion.
+ *
+ * <h3>Example Usage:</h3>
+ *
+ * <pre>{@code
+ * ExperimentProgress progress = ExperimentProgress.builder()
+ *     .experimentId(1L)
+ *     .completedRuns(5)
+ *     .totalRuns(12)
+ *     .progressPercent(41.67)
+ *     .build();
+ * }</pre>
+ *
+ * <h3>WebSocket Integration:</h3>
+ *
+ * <p>This DTO is serialised and sent to clients via WebSocket messages during experiment execution.
+ * Clients can subscribe to {@code /topic/experiments/{id}/progress} to receive these updates.
+ *
+ * @author William Stephen
+ * @see com.locallab.dto.WebSocketMessage
+ * @see com.locallab.service.ExperimentExecutorService
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentProgress {
+
+    /**
+     * The unique identifier of the experiment.
+     *
+     * <p>Used by clients to associate progress updates with the correct experiment.
+     */
+    private Long experimentId;
+
+    /**
+     * The number of runs that have completed.
+     *
+     * <p>This includes both successful and failed runs. Incremented after each run finishes
+     * regardless of outcome.
+     */
+    private int completedRuns;
+
+    /**
+     * The total number of runs to be executed.
+     *
+     * <p>Calculated from the experiment configuration: models x embeddings x iterations.
+     */
+    private int totalRuns;
+
+    /**
+     * The percentage of the experiment that has completed.
+     *
+     * <p>Calculated as: (completedRuns / totalRuns) * 100. Range: 0.0 to 100.0.
+     */
+    private double progressPercent;
+}

--- a/backend/src/main/java/com/locallab/dto/Hyperparameters.java
+++ b/backend/src/main/java/com/locallab/dto/Hyperparameters.java
@@ -1,0 +1,99 @@
+package com.locallab.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO representing hyperparameters for model generation.
+ *
+ * <p>Contains configuration values that control the behaviour of LLM generation, including
+ * temperature, top-p, top-k, context window size, and maximum token limits. All fields are optional
+ * with sensible defaults applied at execution time.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * Hyperparameters params = Hyperparameters.builder()
+ *     .temperature(0.7)
+ *     .topP(0.9)
+ *     .topK(40)
+ *     .contextWindow(4096)
+ *     .maxTokens(1000)
+ *     .build();
+ * }</pre>
+ *
+ * <h3>Validation Constraints:</h3>
+ *
+ * <ul>
+ *   <li>temperature: 0.0 to 2.0 (controls randomness)
+ *   <li>topP: 0.0 to 1.0 (nucleus sampling probability)
+ *   <li>topK: 1 to 100 (top-k sampling)
+ *   <li>contextWindow: 512 to 128,000 (context window size in tokens)
+ *   <li>maxTokens: minimum 1 if provided (maximum response length)
+ * </ul>
+ *
+ * @author William Stephen
+ * @see com.locallab.dto.ExperimentConfig
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Hyperparameters {
+
+    /**
+     * Controls randomness in generation.
+     *
+     * <p>Higher values (e.g., 1.5) make output more creative and diverse, whilst lower values
+     * (e.g., 0.2) make output more focused and deterministic. Default is typically 0.7.
+     */
+    @DecimalMin(value = "0.0", message = "Temperature must be at least 0.0")
+    @DecimalMax(value = "2.0", message = "Temperature must not exceed 2.0")
+    private Double temperature;
+
+    /**
+     * Nucleus sampling probability threshold.
+     *
+     * <p>Considers only tokens whose cumulative probability exceeds this value. A value of 0.9
+     * means the model considers the smallest set of tokens whose cumulative probability is at least
+     * 90%.
+     */
+    @DecimalMin(value = "0.0", message = "Top P must be at least 0.0")
+    @DecimalMax(value = "1.0", message = "Top P must not exceed 1.0")
+    private Double topP;
+
+    /**
+     * Top-k sampling parameter.
+     *
+     * <p>Limits the number of highest-probability tokens to consider for each step. A value of 40
+     * means only the top 40 most likely tokens are considered.
+     */
+    @Min(value = 1, message = "Top K must be at least 1")
+    @Max(value = 100, message = "Top K must not exceed 100")
+    private Integer topK;
+
+    /**
+     * Context window size in tokens.
+     *
+     * <p>Determines the maximum number of tokens the model can process in a single request,
+     * including both the prompt and the generated response.
+     */
+    @Min(value = 512, message = "Context window must be at least 512")
+    @Max(value = 128000, message = "Context window must not exceed 128,000")
+    private Integer contextWindow;
+
+    /**
+     * Maximum number of tokens to generate.
+     *
+     * <p>Caps the length of the model's response. If not specified, the model will generate until
+     * it reaches a natural stopping point or hits the context window limit.
+     */
+    @Min(value = 1, message = "Max tokens must be at least 1")
+    private Integer maxTokens;
+}

--- a/backend/src/main/java/com/locallab/dto/LeaderboardData.java
+++ b/backend/src/main/java/com/locallab/dto/LeaderboardData.java
@@ -1,0 +1,39 @@
+package com.locallab.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Container for leaderboard results returned by the analytics service.
+ *
+ * <p>Contains a list of leaderboard entries (one per model) along with metadata about the total
+ * number of runs included in the analysis.
+ *
+ * @see LeaderboardEntry
+ * @see LeaderboardFilter
+ * @see com.locallab.service.AnalyticsService
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeaderboardData {
+
+    /**
+     * The list of leaderboard entries, one per model.
+     *
+     * <p>Entries are sorted according to the filter criteria provided in the request.
+     */
+    private List<LeaderboardEntry> entries;
+
+    /**
+     * The total number of runs included in this leaderboard analysis.
+     *
+     * <p>This includes both successful and failed runs across all models.
+     */
+    private int totalRuns;
+}

--- a/backend/src/main/java/com/locallab/dto/LeaderboardEntry.java
+++ b/backend/src/main/java/com/locallab/dto/LeaderboardEntry.java
@@ -1,0 +1,107 @@
+package com.locallab.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents a single entry in the leaderboard for a specific model.
+ *
+ * <p>Contains aggregated metrics for a model including run counts, success rates, and performance
+ * statistics (tokens per second, duration, time to first token).
+ *
+ * <h3>Metric Calculations:</h3>
+ *
+ * <ul>
+ *   <li>Success rate is calculated as: (successCount / runCount) * 100
+ *   <li>Average metrics are calculated only from successful runs
+ *   <li>Min/max values represent the extremes observed in successful runs
+ * </ul>
+ *
+ * @see LeaderboardData
+ * @see com.locallab.service.AnalyticsService
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeaderboardEntry {
+
+    /**
+     * The name of the model this entry represents.
+     *
+     * <p>This corresponds to the Ollama model name (e.g., "qwen2.5-coder:7b").
+     */
+    private String modelName;
+
+    /**
+     * The total number of runs for this model.
+     *
+     * <p>Includes both successful and failed runs.
+     */
+    private int runCount;
+
+    /**
+     * The number of successful runs for this model.
+     *
+     * <p>Only runs with status SUCCESS are counted.
+     */
+    private int successCount;
+
+    /**
+     * The success rate as a percentage (0-100).
+     *
+     * <p>Calculated as: (successCount / runCount) * 100
+     */
+    private Double successRate;
+
+    /**
+     * The average tokens per second across successful runs.
+     *
+     * <p>May be null if no successful runs have TPS data.
+     */
+    private Double avgTokensPerSecond;
+
+    /**
+     * The minimum tokens per second observed in successful runs.
+     *
+     * <p>May be null if no successful runs have TPS data.
+     */
+    private Double minTokensPerSecond;
+
+    /**
+     * The maximum tokens per second observed in successful runs.
+     *
+     * <p>May be null if no successful runs have TPS data.
+     */
+    private Double maxTokensPerSecond;
+
+    /**
+     * The average duration in milliseconds across successful runs.
+     *
+     * <p>May be null if no successful runs have duration data.
+     */
+    private Double avgDurationMs;
+
+    /**
+     * The minimum duration in milliseconds observed in successful runs.
+     *
+     * <p>May be null if no successful runs have duration data.
+     */
+    private Long minDurationMs;
+
+    /**
+     * The maximum duration in milliseconds observed in successful runs.
+     *
+     * <p>May be null if no successful runs have duration data.
+     */
+    private Long maxDurationMs;
+
+    /**
+     * The average time to first token in milliseconds across successful runs.
+     *
+     * <p>May be null if no successful runs have TTFT data.
+     */
+    private Double avgTimeToFirstTokenMs;
+}

--- a/backend/src/main/java/com/locallab/dto/LeaderboardFilter.java
+++ b/backend/src/main/java/com/locallab/dto/LeaderboardFilter.java
@@ -1,0 +1,75 @@
+package com.locallab.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Filter criteria for generating leaderboard data.
+ *
+ * <p>This DTO allows clients to specify various filtering and sorting options when retrieving
+ * leaderboard data from the analytics service. All fields are optional, allowing for flexible
+ * querying.
+ *
+ * <h3>Supported Sort Fields:</h3>
+ *
+ * <ul>
+ *   <li>{@code "tps"} - Sort by average tokens per second
+ *   <li>{@code "duration"} - Sort by average duration in milliseconds
+ *   <li>{@code "ttft"} - Sort by average time to first token in milliseconds
+ *   <li>{@code "successRate"} - Sort by success rate percentage
+ * </ul>
+ *
+ * <h3>Sort Order:</h3>
+ *
+ * <ul>
+ *   <li>{@code "asc"} - Ascending order (lowest first)
+ *   <li>{@code "desc"} - Descending order (highest first)
+ * </ul>
+ *
+ * @see com.locallab.dto.LeaderboardData
+ * @see com.locallab.service.AnalyticsService
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeaderboardFilter {
+
+    /**
+     * Filter results to a specific experiment.
+     *
+     * <p>When provided, only runs belonging to this experiment will be included in the leaderboard.
+     */
+    private Long experimentId;
+
+    /**
+     * Filter results to a specific model.
+     *
+     * <p>When provided, only runs using this model will be included in the leaderboard.
+     */
+    private String modelName;
+
+    /**
+     * Filter results to runs using a specific embedding model.
+     *
+     * <p>When provided, only RAG runs using this embedding model will be included.
+     */
+    private String embeddingModel;
+
+    /**
+     * The field to sort results by.
+     *
+     * <p>Valid values: {@code "tps"}, {@code "duration"}, {@code "ttft"}, {@code "successRate"}.
+     * Defaults to {@code "tps"} if not specified.
+     */
+    @Builder.Default private String sortBy = "tps";
+
+    /**
+     * The sort direction.
+     *
+     * <p>Valid values: {@code "asc"}, {@code "desc"}. Defaults to {@code "desc"} if not specified.
+     */
+    @Builder.Default private String sortOrder = "desc";
+}

--- a/backend/src/main/java/com/locallab/dto/ModelMetrics.java
+++ b/backend/src/main/java/com/locallab/dto/ModelMetrics.java
@@ -1,0 +1,89 @@
+package com.locallab.dto;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Detailed metrics for a specific model, optionally scoped to an experiment.
+ *
+ * <p>Provides comprehensive performance statistics including run counts, success rates, average
+ * performance metrics, and per-iteration breakdowns.
+ *
+ * @see RunSummary
+ * @see com.locallab.service.AnalyticsService
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ModelMetrics {
+
+    /**
+     * The name of the model these metrics are for.
+     *
+     * <p>Corresponds to the Ollama model name (e.g., "qwen2.5-coder:7b").
+     */
+    private String modelName;
+
+    /**
+     * The total number of runs for this model.
+     *
+     * <p>Includes all runs regardless of status.
+     */
+    private int totalRuns;
+
+    /**
+     * The number of successful runs.
+     *
+     * <p>Runs with status SUCCESS.
+     */
+    private int successfulRuns;
+
+    /**
+     * The number of failed runs.
+     *
+     * <p>Runs with status FAILED.
+     */
+    private int failedRuns;
+
+    /**
+     * The success rate as a percentage (0-100).
+     *
+     * <p>Calculated as: (successfulRuns / totalRuns) * 100
+     */
+    private Double successRate;
+
+    /**
+     * The average tokens per second across successful runs.
+     *
+     * <p>May be null if no successful runs have TPS data.
+     */
+    private Double avgTokensPerSecond;
+
+    /**
+     * The average duration in milliseconds across successful runs.
+     *
+     * <p>May be null if no successful runs have duration data.
+     */
+    private Double avgDurationMs;
+
+    /**
+     * The average time to first token in milliseconds across successful runs.
+     *
+     * <p>May be null if no successful runs have TTFT data.
+     */
+    private Double avgTimeToFirstTokenMs;
+
+    /**
+     * Runs grouped by iteration number.
+     *
+     * <p>The key is the iteration number (1-indexed), and the value is a list of run summaries for
+     * that iteration. This allows analysis of performance consistency across iterations.
+     */
+    private Map<Integer, List<RunSummary>> runsByIteration;
+}

--- a/backend/src/main/java/com/locallab/dto/RunSummary.java
+++ b/backend/src/main/java/com/locallab/dto/RunSummary.java
@@ -1,0 +1,48 @@
+package com.locallab.dto;
+
+import com.locallab.model.enums.RunStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A summary view of an experiment run for use in analytics.
+ *
+ * <p>Provides a lightweight representation of a run's key metrics without the full output or
+ * configuration details. Used in iteration-based groupings within {@link ModelMetrics}.
+ *
+ * @see ModelMetrics
+ * @see com.locallab.model.ExperimentRun
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RunSummary {
+
+    /** The unique identifier of the run. */
+    private Long id;
+
+    /**
+     * The status of the run.
+     *
+     * @see RunStatus
+     */
+    private RunStatus status;
+
+    /**
+     * The total duration of the run in milliseconds.
+     *
+     * <p>May be null for pending or failed runs.
+     */
+    private Long durationMs;
+
+    /**
+     * The tokens per second throughput metric.
+     *
+     * <p>May be null for pending or failed runs.
+     */
+    private Double tokensPerSecond;
+}

--- a/backend/src/main/java/com/locallab/dto/WebSocketMessage.java
+++ b/backend/src/main/java/com/locallab/dto/WebSocketMessage.java
@@ -1,0 +1,76 @@
+package com.locallab.dto;
+
+import java.time.Instant;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO representing a message sent via WebSocket during experiment execution.
+ *
+ * <p>This class provides a standardised envelope for all WebSocket messages sent during experiment
+ * execution. It includes the message type, payload, and timestamp for client-side processing.
+ *
+ * <h3>Message Types:</h3>
+ *
+ * <ul>
+ *   <li>{@code RUN_STARTED} - Sent when a new run begins execution. Payload contains run config.
+ *   <li>{@code RUN_COMPLETED} - Sent when a run finishes. Payload contains the ExperimentRun.
+ *   <li>{@code PROGRESS} - Sent after each run completes. Payload contains ExperimentProgress.
+ *   <li>{@code EXPERIMENT_COMPLETED} - Sent when all runs finish. Payload is null.
+ *   <li>{@code EXPERIMENT_PAUSED} - Sent when experiment is paused. Payload is null.
+ *   <li>{@code EXPERIMENT_FAILED} - Sent when experiment fails/is cancelled. Payload may contain
+ *       error details.
+ * </ul>
+ *
+ * <h3>Example Usage:</h3>
+ *
+ * <pre>{@code
+ * WebSocketMessage message = WebSocketMessage.builder()
+ *     .type("RUN_COMPLETED")
+ *     .payload(experimentRun)
+ *     .timestamp(Instant.now())
+ *     .build();
+ * }</pre>
+ *
+ * <h3>WebSocket Destination:</h3>
+ *
+ * <p>Messages are published to: {@code /topic/experiments/{experimentId}/progress}
+ *
+ * @author William Stephen
+ * @see com.locallab.dto.ExperimentProgress
+ * @see com.locallab.service.ExperimentExecutorService
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WebSocketMessage {
+
+    /**
+     * The type of message being sent.
+     *
+     * <p>Used by clients to determine how to process the payload. Standard types include:
+     * RUN_STARTED, RUN_COMPLETED, PROGRESS, EXPERIMENT_COMPLETED, EXPERIMENT_PAUSED,
+     * EXPERIMENT_FAILED.
+     */
+    private String type;
+
+    /**
+     * The message payload.
+     *
+     * <p>The structure of the payload depends on the message type. Can be null for messages like
+     * EXPERIMENT_COMPLETED that don't require additional data.
+     */
+    private Object payload;
+
+    /**
+     * The timestamp when this message was created.
+     *
+     * <p>Used by clients for ordering and logging purposes. Set to the instant when the message is
+     * constructed.
+     */
+    private Instant timestamp;
+}

--- a/backend/src/main/java/com/locallab/dto/request/ExperimentRequest.java
+++ b/backend/src/main/java/com/locallab/dto/request/ExperimentRequest.java
@@ -1,0 +1,86 @@
+package com.locallab.dto.request;
+
+import com.locallab.dto.ExperimentConfig;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Request DTO for creating and updating experiments.
+ *
+ * <p>This class encapsulates all fields required to create or update an Experiment entity.
+ * Validation annotations ensure that incoming requests meet the constraints defined in the API
+ * contract.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * ExperimentRequest request = ExperimentRequest.builder()
+ *     .name("LLM Code Review Comparison")
+ *     .taskTemplateId(1L)
+ *     .config(ExperimentConfig.builder()
+ *         .models(List.of("qwen2.5-coder:7b", "codellama:7b"))
+ *         .iterations(3)
+ *         .contextMode("NONE")
+ *         .hyperparameters(Hyperparameters.builder()
+ *             .temperature(0.7)
+ *             .build())
+ *         .build())
+ *     .build();
+ * }</pre>
+ *
+ * <h3>Validation Constraints:</h3>
+ *
+ * <ul>
+ *   <li>name: Required, maximum 200 characters
+ *   <li>taskTemplateId: Optional, references existing TaskTemplate if provided
+ *   <li>config: Required, contains experiment configuration with nested validation
+ * </ul>
+ *
+ * @author William Stephen
+ * @see com.locallab.model.Experiment
+ * @see ExperimentConfig
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentRequest {
+
+    /**
+     * Name of the experiment.
+     *
+     * <p>A descriptive name to identify the experiment in listings and reports.
+     *
+     * <p>Example: "LLM Code Review Comparison"
+     */
+    @NotBlank(message = "Name is required")
+    @Size(max = 200, message = "Name must not exceed 200 characters")
+    private String name;
+
+    /**
+     * ID of the task template to use for this experiment.
+     *
+     * <p>Optional. If provided, references an existing TaskTemplate that defines the prompt
+     * structure for the experiment. Experiments can be created without a task template for ad-hoc
+     * testing.
+     */
+    private Long taskTemplateId;
+
+    /**
+     * Configuration for the experiment.
+     *
+     * <p>Contains all settings required to execute the experiment, including model selection,
+     * iterations, context mode, and hyperparameters. Nested validation is applied to ensure all
+     * config constraints are satisfied.
+     */
+    @NotNull(message = "Configuration is required")
+    @Valid
+    private ExperimentConfig config;
+}

--- a/backend/src/main/java/com/locallab/repository/ExperimentRunRepository.java
+++ b/backend/src/main/java/com/locallab/repository/ExperimentRunRepository.java
@@ -94,6 +94,26 @@ public interface ExperimentRunRepository extends JpaRepository<ExperimentRun, Lo
     List<ExperimentRun> findByModelName(String modelName);
 
     /**
+     * Finds all runs for a specific experiment and model combination.
+     *
+     * <p>This method enables filtering runs by both experiment and model name, which is useful for
+     * calculating model-specific metrics within a single experiment context.
+     *
+     * <p>For example, to find all runs for a specific model in an experiment:
+     *
+     * <pre>{@code
+     * List<ExperimentRun> modelRuns =
+     *     experimentRunRepository.findByExperimentIdAndModelName(
+     *         experiment.getId(), "qwen2.5-coder:7b");
+     * }</pre>
+     *
+     * @param experimentId the ID of the experiment to filter by
+     * @param modelName the name of the model to filter by
+     * @return a list of experiment runs matching both criteria, or an empty list if none found
+     */
+    List<ExperimentRun> findByExperimentIdAndModelName(Long experimentId, String modelName);
+
+    /**
      * Calculates the average tokens per second for successful runs in an experiment.
      *
      * <p>This aggregation query computes the mean throughput metric across all successful runs,

--- a/backend/src/main/java/com/locallab/service/AnalyticsService.java
+++ b/backend/src/main/java/com/locallab/service/AnalyticsService.java
@@ -1,0 +1,402 @@
+package com.locallab.service;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.DoubleSummaryStatistics;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.LongSummaryStatistics;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.locallab.dto.LeaderboardData;
+import com.locallab.dto.LeaderboardEntry;
+import com.locallab.dto.LeaderboardFilter;
+import com.locallab.dto.ModelMetrics;
+import com.locallab.dto.RunSummary;
+import com.locallab.model.ExperimentRun;
+import com.locallab.model.enums.RunStatus;
+import com.locallab.repository.ExperimentRunRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Service for aggregating and analysing experiment run metrics.
+ *
+ * <p>Provides leaderboard generation, model-specific metrics, and cross-model comparison
+ * capabilities. All operations are read-only and transactional.
+ *
+ * <h3>Key Features:</h3>
+ *
+ * <ul>
+ *   <li>Leaderboard generation with filtering by experiment, model, and embedding model
+ *   <li>Sorting by various metrics (TPS, duration, TTFT, success rate)
+ *   <li>Detailed per-model metrics with iteration breakdowns
+ *   <li>Cross-model comparison within experiments
+ * </ul>
+ *
+ * <h3>Exception Handling:</h3>
+ *
+ * <ul>
+ *   <li>{@link EntityNotFoundException} - Thrown when no runs are found for a specified model
+ * </ul>
+ *
+ * @author William Stephen
+ * @see LeaderboardData
+ * @see ModelMetrics
+ * @see ExperimentRunRepository
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnalyticsService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AnalyticsService.class);
+
+    private final ExperimentRunRepository experimentRunRepository;
+
+    /**
+     * Generates leaderboard data based on filter criteria.
+     *
+     * <p>Aggregates metrics across experiment runs, grouping by model name. Results are sorted
+     * according to the filter's sortBy and sortOrder parameters.
+     *
+     * <h3>Filtering:</h3>
+     *
+     * <ul>
+     *   <li>If experimentId is provided, only runs from that experiment are included
+     *   <li>If modelName is provided, only runs using that model are included
+     *   <li>If embeddingModel is provided, only runs using that embedding model are included
+     * </ul>
+     *
+     * @param filter the filter criteria for generating the leaderboard
+     * @return leaderboard data with ranked models, or empty leaderboard if no runs match
+     */
+    public LeaderboardData getLeaderboard(LeaderboardFilter filter) {
+        LOGGER.debug("Generating leaderboard with filter: {}", filter);
+
+        List<ExperimentRun> runs = fetchFilteredRuns(filter);
+
+        if (runs.isEmpty()) {
+            LOGGER.debug("No runs found matching filter criteria");
+            return LeaderboardData.builder().entries(Collections.emptyList()).totalRuns(0).build();
+        }
+
+        // Group by model and calculate metrics
+        Map<String, List<ExperimentRun>> runsByModel =
+                runs.stream()
+                        .filter(r -> r.getStatus() == RunStatus.SUCCESS)
+                        .collect(Collectors.groupingBy(ExperimentRun::getModelName));
+
+        List<LeaderboardEntry> entries =
+                runsByModel.entrySet().stream()
+                        .map(
+                                entry ->
+                                        calculateLeaderboardEntry(
+                                                entry.getKey(), entry.getValue(), runs))
+                        .sorted(getComparator(filter.getSortBy(), filter.getSortOrder()))
+                        .toList();
+
+        LOGGER.debug(
+                "Generated leaderboard with {} entries from {} total runs",
+                entries.size(),
+                runs.size());
+
+        return LeaderboardData.builder().entries(entries).totalRuns(runs.size()).build();
+    }
+
+    /**
+     * Gets detailed metrics for a specific model.
+     *
+     * <p>Calculates comprehensive metrics including run counts, success rates, average performance
+     * metrics, and per-iteration breakdowns.
+     *
+     * @param modelName the model name to get metrics for
+     * @param experimentId optional experiment filter; if null, metrics span all experiments
+     * @return detailed model metrics
+     * @throws EntityNotFoundException if no runs are found for the specified model
+     */
+    public ModelMetrics getModelMetrics(String modelName, Long experimentId) {
+        LOGGER.debug("Getting metrics for model: {}, experimentId: {}", modelName, experimentId);
+
+        List<ExperimentRun> runs;
+
+        if (experimentId != null) {
+            runs = experimentRunRepository.findByExperimentIdAndModelName(experimentId, modelName);
+        } else {
+            runs = experimentRunRepository.findByModelName(modelName);
+        }
+
+        if (runs.isEmpty()) {
+            LOGGER.warn("No runs found for model: {}", modelName);
+            throw new EntityNotFoundException("No runs found for model: " + modelName);
+        }
+
+        List<ExperimentRun> successRuns =
+                runs.stream().filter(r -> r.getStatus() == RunStatus.SUCCESS).toList();
+
+        int failedRuns = (int) runs.stream().filter(r -> r.getStatus() == RunStatus.FAILED).count();
+
+        Map<Integer, List<RunSummary>> runsByIteration = groupByIteration(runs);
+
+        LOGGER.debug(
+                "Calculated metrics for model {} - {} total runs, {} successful, {} failed",
+                modelName,
+                runs.size(),
+                successRuns.size(),
+                failedRuns);
+
+        return ModelMetrics.builder()
+                .modelName(modelName)
+                .totalRuns(runs.size())
+                .successfulRuns(successRuns.size())
+                .failedRuns(failedRuns)
+                .successRate((double) successRuns.size() / runs.size() * 100)
+                .avgTokensPerSecond(
+                        calculateAverage(successRuns, ExperimentRun::getTokensPerSecond))
+                .avgDurationMs(calculateAverageLong(successRuns, ExperimentRun::getDurationMs))
+                .avgTimeToFirstTokenMs(
+                        calculateAverageLong(successRuns, ExperimentRun::getTimeToFirstTokenMs))
+                .runsByIteration(runsByIteration)
+                .build();
+    }
+
+    /**
+     * Compares all models within an experiment.
+     *
+     * <p>Returns metrics for each unique model used in the experiment, enabling side-by-side
+     * comparison of model performance.
+     *
+     * @param experimentId the experiment to analyse
+     * @return map of model name to metrics; empty map if no runs exist
+     */
+    public Map<String, ModelMetrics> compareModels(Long experimentId) {
+        LOGGER.debug("Comparing models for experiment: {}", experimentId);
+
+        List<ExperimentRun> runs =
+                experimentRunRepository.findByExperimentIdOrderByIterationAsc(experimentId);
+
+        if (runs.isEmpty()) {
+            LOGGER.debug("No runs found for experiment: {}", experimentId);
+            return Collections.emptyMap();
+        }
+
+        Set<String> modelNames =
+                runs.stream().map(ExperimentRun::getModelName).collect(Collectors.toSet());
+
+        Map<String, ModelMetrics> comparison = new LinkedHashMap<>();
+        for (String modelName : modelNames) {
+            comparison.put(modelName, getModelMetrics(modelName, experimentId));
+        }
+
+        LOGGER.debug("Compared {} models for experiment {}", comparison.size(), experimentId);
+        return comparison;
+    }
+
+    /**
+     * Fetches runs matching the filter criteria.
+     *
+     * @param filter the filter to apply
+     * @return list of matching runs
+     */
+    private List<ExperimentRun> fetchFilteredRuns(LeaderboardFilter filter) {
+        List<ExperimentRun> runs;
+
+        if (filter.getExperimentId() != null) {
+            runs =
+                    experimentRunRepository.findByExperimentIdOrderByIterationAsc(
+                            filter.getExperimentId());
+        } else if (filter.getModelName() != null && !filter.getModelName().isBlank()) {
+            runs = experimentRunRepository.findByModelName(filter.getModelName());
+        } else {
+            runs = experimentRunRepository.findAll();
+        }
+
+        // Apply additional filters
+        if (filter.getModelName() != null
+                && !filter.getModelName().isBlank()
+                && filter.getExperimentId() != null) {
+            runs =
+                    runs.stream()
+                            .filter(r -> filter.getModelName().equals(r.getModelName()))
+                            .toList();
+        }
+
+        if (filter.getEmbeddingModel() != null && !filter.getEmbeddingModel().isBlank()) {
+            runs =
+                    runs.stream()
+                            .filter(
+                                    r ->
+                                            r.getEmbeddingModel() != null
+                                                    && filter.getEmbeddingModel()
+                                                            .equals(
+                                                                    r.getEmbeddingModel()
+                                                                            .getOllamaModelName()))
+                            .toList();
+        }
+
+        return runs;
+    }
+
+    /**
+     * Calculates a leaderboard entry for a specific model.
+     *
+     * @param modelName the model name
+     * @param successRuns list of successful runs for this model
+     * @param allRuns list of all runs (for total count calculation)
+     * @return the calculated leaderboard entry
+     */
+    private LeaderboardEntry calculateLeaderboardEntry(
+            String modelName, List<ExperimentRun> successRuns, List<ExperimentRun> allRuns) {
+
+        long totalRunsForModel =
+                allRuns.stream().filter(r -> r.getModelName().equals(modelName)).count();
+
+        DoubleSummaryStatistics tpsStats =
+                successRuns.stream()
+                        .filter(r -> r.getTokensPerSecond() != null)
+                        .mapToDouble(ExperimentRun::getTokensPerSecond)
+                        .summaryStatistics();
+
+        LongSummaryStatistics durationStats =
+                successRuns.stream()
+                        .filter(r -> r.getDurationMs() != null)
+                        .mapToLong(ExperimentRun::getDurationMs)
+                        .summaryStatistics();
+
+        LongSummaryStatistics ttftStats =
+                successRuns.stream()
+                        .filter(r -> r.getTimeToFirstTokenMs() != null)
+                        .mapToLong(ExperimentRun::getTimeToFirstTokenMs)
+                        .summaryStatistics();
+
+        return LeaderboardEntry.builder()
+                .modelName(modelName)
+                .runCount((int) totalRunsForModel)
+                .successCount(successRuns.size())
+                .successRate((double) successRuns.size() / totalRunsForModel * 100)
+                .avgTokensPerSecond(tpsStats.getCount() > 0 ? tpsStats.getAverage() : null)
+                .minTokensPerSecond(tpsStats.getCount() > 0 ? tpsStats.getMin() : null)
+                .maxTokensPerSecond(tpsStats.getCount() > 0 ? tpsStats.getMax() : null)
+                .avgDurationMs(durationStats.getCount() > 0 ? durationStats.getAverage() : null)
+                .minDurationMs(durationStats.getCount() > 0 ? durationStats.getMin() : null)
+                .maxDurationMs(durationStats.getCount() > 0 ? durationStats.getMax() : null)
+                .avgTimeToFirstTokenMs(ttftStats.getCount() > 0 ? ttftStats.getAverage() : null)
+                .build();
+    }
+
+    /**
+     * Gets a comparator for sorting leaderboard entries.
+     *
+     * @param sortBy the field to sort by
+     * @param sortOrder the sort direction ("asc" or "desc")
+     * @return comparator for sorting entries
+     */
+    private Comparator<LeaderboardEntry> getComparator(String sortBy, String sortOrder) {
+        String effectiveSortBy = sortBy != null ? sortBy : "tps";
+        Comparator<LeaderboardEntry> comparator;
+
+        if ("duration".equals(effectiveSortBy)) {
+            comparator =
+                    Comparator.comparing(
+                            LeaderboardEntry::getAvgDurationMs,
+                            Comparator.nullsLast(Comparator.naturalOrder()));
+        } else if ("ttft".equals(effectiveSortBy)) {
+            comparator =
+                    Comparator.comparing(
+                            LeaderboardEntry::getAvgTimeToFirstTokenMs,
+                            Comparator.nullsLast(Comparator.naturalOrder()));
+        } else if ("successRate".equals(effectiveSortBy)) {
+            comparator =
+                    Comparator.comparing(
+                            LeaderboardEntry::getSuccessRate,
+                            Comparator.nullsLast(Comparator.naturalOrder()));
+        } else {
+            comparator =
+                    Comparator.comparing(
+                            LeaderboardEntry::getAvgTokensPerSecond,
+                            Comparator.nullsLast(Comparator.naturalOrder()));
+        }
+
+        if ("asc".equalsIgnoreCase(sortOrder)) {
+            return comparator;
+        }
+        return comparator.reversed();
+    }
+
+    /**
+     * Calculates the average of a Double field across runs.
+     *
+     * @param runs the runs to aggregate
+     * @param getter the getter function for the field
+     * @return the average, or null if no valid values exist
+     */
+    private Double calculateAverage(
+            List<ExperimentRun> runs, Function<ExperimentRun, Double> getter) {
+
+        List<Double> values = runs.stream().map(getter).filter(v -> v != null).toList();
+
+        if (values.isEmpty()) {
+            return null;
+        }
+
+        return values.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+    }
+
+    /**
+     * Calculates the average of a Long field across runs, returning as Double.
+     *
+     * @param runs the runs to aggregate
+     * @param getter the getter function for the field
+     * @return the average as Double, or null if no valid values exist
+     */
+    private Double calculateAverageLong(
+            List<ExperimentRun> runs, Function<ExperimentRun, Long> getter) {
+
+        List<Long> values = runs.stream().map(getter).filter(v -> v != null).toList();
+
+        if (values.isEmpty()) {
+            return null;
+        }
+
+        return values.stream().mapToLong(Long::longValue).average().orElse(0.0);
+    }
+
+    /**
+     * Groups runs by iteration number, converting to RunSummary objects.
+     *
+     * @param runs the runs to group
+     * @return map of iteration number to list of run summaries
+     */
+    private Map<Integer, List<RunSummary>> groupByIteration(List<ExperimentRun> runs) {
+        return runs.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                ExperimentRun::getIteration,
+                                LinkedHashMap::new,
+                                Collectors.mapping(this::toRunSummary, Collectors.toList())));
+    }
+
+    /**
+     * Converts an ExperimentRun to a RunSummary.
+     *
+     * @param run the run to convert
+     * @return the run summary
+     */
+    private RunSummary toRunSummary(ExperimentRun run) {
+        return RunSummary.builder()
+                .id(run.getId())
+                .status(run.getStatus())
+                .durationMs(run.getDurationMs())
+                .tokensPerSecond(run.getTokensPerSecond())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/locallab/service/ExperimentExecutorService.java
+++ b/backend/src/main/java/com/locallab/service/ExperimentExecutorService.java
@@ -1,0 +1,639 @@
+package com.locallab.service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.locallab.dto.ExperimentConfig;
+import com.locallab.dto.ExperimentExecutionState;
+import com.locallab.dto.ExperimentProgress;
+import com.locallab.dto.RetrievedChunk;
+import com.locallab.dto.WebSocketMessage;
+import com.locallab.dto.request.GenerationRequest;
+import com.locallab.dto.response.GenerationResponse;
+import com.locallab.model.Experiment;
+import com.locallab.model.ExperimentRun;
+import com.locallab.model.SystemPrompt;
+import com.locallab.model.TaskTemplate;
+import com.locallab.model.enums.ExperimentStatus;
+import com.locallab.model.enums.RunStatus;
+import com.locallab.repository.ExperimentRepository;
+import com.locallab.repository.ExperimentRunRepository;
+import com.locallab.repository.SystemPromptRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Service for executing experiments asynchronously.
+ *
+ * <p>This service manages the execution lifecycle of experiments, including starting, pausing,
+ * cancelling, and resuming experiment runs. It coordinates between multiple services to generate
+ * model responses and publish progress updates via WebSocket.
+ *
+ * <h3>Execution Flow:</h3>
+ *
+ * <ol>
+ *   <li>Generate run configurations from experiment config (models x embeddings x iterations)
+ *   <li>Execute each run sequentially (to respect local resource constraints)
+ *   <li>Persist results immediately after each run
+ *   <li>Publish progress updates via WebSocket
+ *   <li>Update experiment status upon completion
+ * </ol>
+ *
+ * <h3>Control Operations:</h3>
+ *
+ * <ul>
+ *   <li><strong>Pause:</strong> Stops execution after current run completes
+ *   <li><strong>Cancel:</strong> Aborts execution and marks experiment as FAILED
+ *   <li><strong>Resume:</strong> Continues from where execution was paused
+ * </ul>
+ *
+ * <h3>WebSocket Messages:</h3>
+ *
+ * <p>Progress updates are published to: {@code /topic/experiments/{id}/progress}
+ *
+ * @author William Stephen
+ * @see ExperimentExecutionState
+ * @see ExperimentProgress
+ * @see WebSocketMessage
+ */
+@Service
+@RequiredArgsConstructor
+public class ExperimentExecutorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExperimentExecutorService.class);
+
+    private final ExperimentRepository experimentRepository;
+    private final ExperimentRunRepository experimentRunRepository;
+    private final OllamaService ollamaService;
+    private final RagService ragService;
+    private final TaskService taskService;
+    private final SystemPromptRepository systemPromptRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ObjectMapper objectMapper;
+
+    /** Tracks execution state for running experiments. Thread-safe for concurrent access. */
+    private final Map<Long, ExperimentExecutionState> executionStates = new ConcurrentHashMap<>();
+
+    /**
+     * Starts experiment execution asynchronously.
+     *
+     * <p>This method validates the experiment status, generates run configurations, and begins
+     * sequential execution of all runs. Progress updates are published via WebSocket.
+     *
+     * @param experimentId the ID of the experiment to start
+     * @throws EntityNotFoundException if the experiment is not found
+     * @throws IllegalStateException if the experiment is not in DRAFT status
+     */
+    @Async
+    public void startExperiment(Long experimentId) {
+        LOGGER.info("Starting experiment: {}", experimentId);
+
+        Experiment experiment = findExperimentById(experimentId);
+
+        if (experiment.getStatus() != ExperimentStatus.DRAFT) {
+            throw new IllegalStateException(
+                    "Experiment must be in DRAFT status to start, current status: "
+                            + experiment.getStatus());
+        }
+
+        updateExperimentStatus(experimentId, ExperimentStatus.RUNNING);
+
+        ExperimentConfig config = parseConfig(experiment.getConfig());
+        List<ExperimentRunConfig> runConfigs = generateRunConfigurations(config);
+
+        ExperimentExecutionState state = new ExperimentExecutionState(experimentId);
+        state.setTotalRuns(runConfigs.size());
+        executionStates.put(experimentId, state);
+
+        LOGGER.info(
+                "Generated {} run configurations for experiment {}",
+                runConfigs.size(),
+                experimentId);
+
+        executeRuns(experiment, runConfigs, state, config);
+    }
+
+    /**
+     * Pauses experiment execution after the current run completes.
+     *
+     * <p>Sets the pause flag on the execution state. The executor will check this flag after each
+     * run and stop if set. The experiment status will be updated to PAUSED.
+     *
+     * @param experimentId the ID of the experiment to pause
+     */
+    public void pauseExperiment(Long experimentId) {
+        LOGGER.info("Pausing experiment: {}", experimentId);
+
+        ExperimentExecutionState state = executionStates.get(experimentId);
+        if (state != null) {
+            state.setPaused(true);
+            LOGGER.info("Pause flag set for experiment: {}", experimentId);
+        } else {
+            LOGGER.warn("No active execution state found for experiment: {}", experimentId);
+        }
+    }
+
+    /**
+     * Cancels experiment execution after the current run completes.
+     *
+     * <p>Sets the cancel flag on the execution state. The executor will check this flag after each
+     * run and stop if set. The experiment status will be updated to FAILED.
+     *
+     * @param experimentId the ID of the experiment to cancel
+     */
+    public void cancelExperiment(Long experimentId) {
+        LOGGER.info("Cancelling experiment: {}", experimentId);
+
+        ExperimentExecutionState state = executionStates.get(experimentId);
+        if (state != null) {
+            state.setCancelled(true);
+            LOGGER.info("Cancel flag set for experiment: {}", experimentId);
+        } else {
+            LOGGER.warn("No active execution state found for experiment: {}", experimentId);
+        }
+    }
+
+    /**
+     * Resumes a paused experiment from where it left off.
+     *
+     * <p>Validates that the experiment is in PAUSED status and restarts execution. Runs that have
+     * already completed will not be re-executed.
+     *
+     * @param experimentId the ID of the experiment to resume
+     * @throws EntityNotFoundException if the experiment is not found
+     * @throws IllegalStateException if the experiment is not in PAUSED status
+     */
+    @Async
+    public void resumeExperiment(Long experimentId) {
+        LOGGER.info("Resuming experiment: {}", experimentId);
+
+        Experiment experiment = findExperimentById(experimentId);
+
+        if (experiment.getStatus() != ExperimentStatus.PAUSED) {
+            throw new IllegalStateException(
+                    "Experiment must be in PAUSED status to resume, current status: "
+                            + experiment.getStatus());
+        }
+
+        updateExperimentStatus(experimentId, ExperimentStatus.RUNNING);
+
+        ExperimentConfig config = parseConfig(experiment.getConfig());
+        List<ExperimentRunConfig> runConfigs = generateRunConfigurations(config);
+
+        List<ExperimentRun> completedRuns =
+                experimentRunRepository.findByExperimentIdOrderByIterationAsc(experimentId);
+        int completedCount = completedRuns.size();
+
+        List<ExperimentRunConfig> remainingConfigs =
+                runConfigs.subList(completedCount, runConfigs.size());
+
+        ExperimentExecutionState state = new ExperimentExecutionState(experimentId);
+        state.setTotalRuns(runConfigs.size());
+        state.setCompletedRuns(completedCount);
+        executionStates.put(experimentId, state);
+
+        LOGGER.info(
+                "Resuming experiment {} with {} remaining runs out of {} total",
+                experimentId,
+                remainingConfigs.size(),
+                runConfigs.size());
+
+        if (remainingConfigs.isEmpty()) {
+            LOGGER.info("No remaining runs for experiment {}, marking as completed", experimentId);
+            updateExperimentStatus(experimentId, ExperimentStatus.COMPLETED);
+            publishMessage(experimentId, "EXPERIMENT_COMPLETED", null);
+            executionStates.remove(experimentId);
+        } else {
+            executeRuns(experiment, remainingConfigs, state, config);
+        }
+    }
+
+    /**
+     * Gets the current progress of an executing experiment.
+     *
+     * @param experimentId the ID of the experiment
+     * @return the experiment progress, or null if not currently executing
+     */
+    public ExperimentProgress getProgress(Long experimentId) {
+        ExperimentExecutionState state = executionStates.get(experimentId);
+        if (state == null) {
+            return null;
+        }
+
+        double progressPercent =
+                state.getTotalRuns() > 0
+                        ? (double) state.getCompletedRuns() / state.getTotalRuns() * 100
+                        : 0;
+
+        return ExperimentProgress.builder()
+                .experimentId(experimentId)
+                .completedRuns(state.getCompletedRuns())
+                .totalRuns(state.getTotalRuns())
+                .progressPercent(progressPercent)
+                .build();
+    }
+
+    /**
+     * Checks if an experiment is currently executing.
+     *
+     * @param experimentId the ID of the experiment
+     * @return true if the experiment is currently executing, false otherwise
+     */
+    public boolean isExecuting(Long experimentId) {
+        return executionStates.containsKey(experimentId);
+    }
+
+    /**
+     * Generates run configurations from experiment config.
+     *
+     * <p>Creates the run matrix: models x embeddings x iterations. If no embedding models are
+     * specified, a single null embedding is used (non-RAG mode).
+     *
+     * @param config the experiment configuration
+     * @return list of run configurations to execute
+     */
+    private List<ExperimentRunConfig> generateRunConfigurations(ExperimentConfig config) {
+        List<ExperimentRunConfig> runConfigs = new ArrayList<>();
+
+        List<String> models = config.getModels();
+        List<String> embeddings = config.getEmbeddingModels();
+        if (embeddings == null || embeddings.isEmpty()) {
+            embeddings = new ArrayList<>();
+            embeddings.add(null);
+        }
+        int iterations = config.getIterations() != null ? config.getIterations() : 1;
+
+        for (String model : models) {
+            for (String embedding : embeddings) {
+                for (int i = 1; i <= iterations; i++) {
+                    runConfigs.add(
+                            ExperimentRunConfig.builder()
+                                    .model(model)
+                                    .embeddingModel(embedding)
+                                    .iteration(i)
+                                    .build());
+                }
+            }
+        }
+
+        return runConfigs;
+    }
+
+    /**
+     * Executes all runs sequentially.
+     *
+     * @param experiment the experiment being executed
+     * @param runConfigs the run configurations to execute
+     * @param state the execution state for tracking progress and control
+     * @param config the experiment configuration
+     */
+    private void executeRuns(
+            Experiment experiment,
+            List<ExperimentRunConfig> runConfigs,
+            ExperimentExecutionState state,
+            ExperimentConfig config) {
+
+        for (ExperimentRunConfig runConfig : runConfigs) {
+            if (state.isPaused()) {
+                LOGGER.info("Experiment {} paused", experiment.getId());
+                updateExperimentStatus(experiment.getId(), ExperimentStatus.PAUSED);
+                publishMessage(experiment.getId(), "EXPERIMENT_PAUSED", null);
+                return;
+            }
+
+            if (state.isCancelled()) {
+                LOGGER.info("Experiment {} cancelled", experiment.getId());
+                updateExperimentStatus(experiment.getId(), ExperimentStatus.FAILED);
+                publishMessage(experiment.getId(), "EXPERIMENT_FAILED", "Cancelled by user");
+                executionStates.remove(experiment.getId());
+                return;
+            }
+
+            publishMessage(experiment.getId(), "RUN_STARTED", runConfig);
+
+            ExperimentRun run = executeSingleRun(experiment, runConfig, config);
+
+            state.setCompletedRuns(state.getCompletedRuns() + 1);
+
+            publishMessage(experiment.getId(), "RUN_COMPLETED", run);
+            publishProgress(experiment.getId(), state);
+        }
+
+        LOGGER.info("Experiment {} completed successfully", experiment.getId());
+        updateExperimentStatus(experiment.getId(), ExperimentStatus.COMPLETED);
+        publishMessage(experiment.getId(), "EXPERIMENT_COMPLETED", null);
+        executionStates.remove(experiment.getId());
+    }
+
+    /**
+     * Executes a single run and persists the result.
+     *
+     * @param experiment the experiment
+     * @param runConfig the run configuration
+     * @param config the experiment configuration
+     * @return the completed experiment run
+     */
+    @Transactional
+    protected ExperimentRun executeSingleRun(
+            Experiment experiment, ExperimentRunConfig runConfig, ExperimentConfig config) {
+
+        LOGGER.debug(
+                "Executing run for experiment {}: model={}, embedding={}, iteration={}",
+                experiment.getId(),
+                runConfig.getModel(),
+                runConfig.getEmbeddingModel(),
+                runConfig.getIteration());
+
+        ExperimentRun run = createInitialRun(experiment, runConfig, config);
+        run = experimentRunRepository.save(run);
+
+        try {
+            executeGeneration(run, experiment, runConfig, config);
+        } catch (Exception e) {
+            handleRunFailure(run, experiment, runConfig, e);
+        }
+
+        return experimentRunRepository.save(run);
+    }
+
+    /** Creates the initial ExperimentRun entity with RUNNING status. */
+    private ExperimentRun createInitialRun(
+            Experiment experiment, ExperimentRunConfig runConfig, ExperimentConfig config) {
+        return ExperimentRun.builder()
+                .experiment(experiment)
+                .modelName(runConfig.getModel())
+                .iteration(runConfig.getIteration())
+                .status(RunStatus.RUNNING)
+                .config(serializeConfig(config))
+                .build();
+    }
+
+    /** Executes the generation and updates the run with results. */
+    private void executeGeneration(
+            ExperimentRun run,
+            Experiment experiment,
+            ExperimentRunConfig runConfig,
+            ExperimentConfig config) {
+
+        String prompt = buildPrompt(experiment, runConfig, config);
+        GenerationRequest generationRequest = buildGenerationRequest(runConfig, config, prompt);
+        applySystemPrompt(run, generationRequest, config);
+
+        GenerationResponse response = ollamaService.generate(generationRequest);
+        updateRunWithSuccess(run, response, experiment, runConfig);
+    }
+
+    /** Builds a GenerationRequest from config and prompt. */
+    private GenerationRequest buildGenerationRequest(
+            ExperimentRunConfig runConfig, ExperimentConfig config, String prompt) {
+        return GenerationRequest.builder()
+                .model(runConfig.getModel())
+                .prompt(prompt)
+                .temperature(
+                        config.getHyperparameters() != null
+                                ? config.getHyperparameters().getTemperature()
+                                : null)
+                .topP(
+                        config.getHyperparameters() != null
+                                ? config.getHyperparameters().getTopP()
+                                : null)
+                .topK(
+                        config.getHyperparameters() != null
+                                ? config.getHyperparameters().getTopK()
+                                : null)
+                .contextWindow(
+                        config.getHyperparameters() != null
+                                ? config.getHyperparameters().getContextWindow()
+                                : null)
+                .maxTokens(
+                        config.getHyperparameters() != null
+                                ? config.getHyperparameters().getMaxTokens()
+                                : null)
+                .build();
+    }
+
+    /** Applies system prompt to the generation request if configured. */
+    private void applySystemPrompt(
+            ExperimentRun run, GenerationRequest request, ExperimentConfig config) {
+        if (config.getSystemPromptId() == null) {
+            return;
+        }
+        SystemPrompt systemPrompt =
+                systemPromptRepository.findById(config.getSystemPromptId()).orElse(null);
+        if (systemPrompt != null) {
+            request.setSystemPrompt(systemPrompt.getContent());
+            run.setSystemPrompt(systemPrompt);
+        }
+    }
+
+    /** Updates the run with successful generation results. */
+    private void updateRunWithSuccess(
+            ExperimentRun run,
+            GenerationResponse response,
+            Experiment experiment,
+            ExperimentRunConfig runConfig) {
+        run.setStatus(RunStatus.SUCCESS);
+        run.setOutput(response.getResponse());
+        run.setDurationMs(response.getDurationMs());
+        run.setTokensPerSecond(response.getTokensPerSecond());
+        run.setTimeToFirstTokenMs(response.getTimeToFirstTokenMs());
+
+        LOGGER.debug(
+                "Run completed successfully for experiment {}, model {}, duration {}ms",
+                experiment.getId(),
+                runConfig.getModel(),
+                response.getDurationMs());
+    }
+
+    /** Handles run failure by setting error status and message. */
+    private void handleRunFailure(
+            ExperimentRun run, Experiment experiment, ExperimentRunConfig runConfig, Exception e) {
+        LOGGER.error(
+                "Run failed for experiment {}, model {}: {}",
+                experiment.getId(),
+                runConfig.getModel(),
+                e.getMessage(),
+                e);
+        run.setStatus(RunStatus.FAILED);
+        run.setErrorMessage(e.getMessage());
+    }
+
+    /**
+     * Builds the prompt for a run, including RAG context if applicable.
+     *
+     * @param experiment the experiment
+     * @param runConfig the run configuration
+     * @param config the experiment configuration
+     * @return the complete prompt string
+     */
+    private String buildPrompt(
+            Experiment experiment, ExperimentRunConfig runConfig, ExperimentConfig config) {
+
+        TaskTemplate taskTemplate = experiment.getTaskTemplate();
+        String promptTemplate =
+                taskTemplate != null ? taskTemplate.getPromptTemplate() : "{{prompt}}";
+
+        String prompt = promptTemplate;
+        if (config.getVariableValues() != null) {
+            for (Map.Entry<String, String> entry : config.getVariableValues().entrySet()) {
+                prompt = prompt.replace("{{" + entry.getKey() + "}}", entry.getValue());
+            }
+        }
+
+        if ("RAG".equalsIgnoreCase(config.getContextMode())
+                && config.getDocumentId() != null
+                && runConfig.getEmbeddingModel() != null) {
+
+            String collectionName =
+                    ragService.buildCollectionName(
+                            config.getDocumentId(), runConfig.getEmbeddingModel());
+
+            List<RetrievedChunk> chunks =
+                    ragService.query(collectionName, prompt, runConfig.getEmbeddingModel(), 5);
+
+            String context = ragService.buildContext(chunks);
+            prompt = context + "\n\n" + prompt;
+        }
+
+        return prompt;
+    }
+
+    /**
+     * Publishes a WebSocket message.
+     *
+     * @param experimentId the experiment ID
+     * @param type the message type
+     * @param payload the message payload
+     */
+    private void publishMessage(Long experimentId, String type, Object payload) {
+        WebSocketMessage message =
+                WebSocketMessage.builder()
+                        .type(type)
+                        .payload(payload)
+                        .timestamp(Instant.now())
+                        .build();
+
+        String destination = "/topic/experiments/" + experimentId + "/progress";
+
+        try {
+            messagingTemplate.convertAndSend(destination, message);
+            LOGGER.debug("Published {} message to {}", type, destination);
+        } catch (Exception e) {
+            LOGGER.error("Failed to publish WebSocket message: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Publishes a progress update message.
+     *
+     * @param experimentId the experiment ID
+     * @param state the execution state
+     */
+    private void publishProgress(Long experimentId, ExperimentExecutionState state) {
+        double progressPercent =
+                state.getTotalRuns() > 0
+                        ? (double) state.getCompletedRuns() / state.getTotalRuns() * 100
+                        : 0;
+
+        ExperimentProgress progressData =
+                ExperimentProgress.builder()
+                        .experimentId(experimentId)
+                        .completedRuns(state.getCompletedRuns())
+                        .totalRuns(state.getTotalRuns())
+                        .progressPercent(progressPercent)
+                        .build();
+
+        publishMessage(experimentId, "PROGRESS", progressData);
+    }
+
+    /**
+     * Parses the experiment config JSON string into an ExperimentConfig object.
+     *
+     * @param configJson the JSON configuration string
+     * @return the parsed ExperimentConfig
+     * @throws IllegalArgumentException if parsing fails
+     */
+    private ExperimentConfig parseConfig(String configJson) {
+        if (configJson == null || configJson.isBlank()) {
+            throw new IllegalArgumentException("Experiment config is required");
+        }
+
+        try {
+            return objectMapper.readValue(configJson, ExperimentConfig.class);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Failed to parse experiment config: {}", e.getMessage());
+            throw new IllegalArgumentException("Invalid experiment config JSON: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Serialises an ExperimentConfig to JSON string.
+     *
+     * @param config the configuration to serialise
+     * @return the JSON string, or null if serialisation fails
+     */
+    private String serializeConfig(ExperimentConfig config) {
+        try {
+            return objectMapper.writeValueAsString(config);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Failed to serialise config: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Finds an experiment by ID.
+     *
+     * @param experimentId the experiment ID
+     * @return the experiment
+     * @throws EntityNotFoundException if not found
+     */
+    private Experiment findExperimentById(Long experimentId) {
+        return experimentRepository
+                .findById(experimentId)
+                .orElseThrow(
+                        () -> new EntityNotFoundException("Experiment not found: " + experimentId));
+    }
+
+    /**
+     * Updates the status of an experiment.
+     *
+     * @param experimentId the experiment ID
+     * @param status the new status
+     */
+    @Transactional
+    protected void updateExperimentStatus(Long experimentId, ExperimentStatus status) {
+        Experiment experiment = findExperimentById(experimentId);
+        experiment.setStatus(status);
+        experimentRepository.save(experiment);
+        LOGGER.info("Updated experiment {} status to {}", experimentId, status);
+    }
+
+    /**
+     * Internal DTO for run configuration.
+     *
+     * <p>Represents a single combination of model, embedding model, and iteration for execution.
+     */
+    @Data
+    @Builder
+    public static class ExperimentRunConfig {
+        private String model;
+        private String embeddingModel;
+        private int iteration;
+    }
+}

--- a/backend/src/main/java/com/locallab/service/ExperimentService.java
+++ b/backend/src/main/java/com/locallab/service/ExperimentService.java
@@ -1,0 +1,376 @@
+package com.locallab.service;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.locallab.dto.ExperimentConfig;
+import com.locallab.dto.request.ExperimentRequest;
+import com.locallab.model.Experiment;
+import com.locallab.model.TaskTemplate;
+import com.locallab.model.enums.ExperimentStatus;
+import com.locallab.repository.ExperimentRepository;
+import com.locallab.repository.TaskTemplateRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Service layer for managing Experiment entities.
+ *
+ * <p>Provides CRUD operations, configuration validation, status management, and run matrix
+ * calculation for experiments. All operations are transactional with read-only optimisation for
+ * query methods.
+ *
+ * <h3>Status Management:</h3>
+ *
+ * <p>Experiments follow a strict lifecycle:
+ *
+ * <ul>
+ *   <li>DRAFT - Initial state, can be updated or deleted
+ *   <li>RUNNING - Experiment in progress, cannot be updated or deleted
+ *   <li>PAUSED - Experiment paused, awaiting resume
+ *   <li>COMPLETED - All runs finished successfully
+ *   <li>FAILED - Experiment terminated due to error or cancellation
+ * </ul>
+ *
+ * <p>Only experiments in DRAFT status can be updated. Running experiments cannot be deleted.
+ *
+ * <h3>Run Matrix Calculation:</h3>
+ *
+ * <p>The total number of runs is calculated as: {@code models × max(embeddingModels, 1) ×
+ * iterations}
+ *
+ * <h3>Exception Handling:</h3>
+ *
+ * <ul>
+ *   <li>{@link EntityNotFoundException} - Thrown when a requested experiment or task template is
+ *       not found
+ *   <li>{@link IllegalStateException} - Thrown when attempting invalid status transitions
+ *   <li>{@link IllegalArgumentException} - Thrown for configuration validation failures
+ * </ul>
+ *
+ * @author William Stephen
+ * @see Experiment
+ * @see ExperimentRepository
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExperimentService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExperimentService.class);
+
+    private final ExperimentRepository experimentRepository;
+    private final TaskTemplateRepository taskTemplateRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Retrieves all experiments ordered by creation date descending.
+     *
+     * @return a list of all experiments with newest first, or an empty list if none exist
+     */
+    public List<Experiment> findAll() {
+        LOGGER.debug("Retrieving all experiments");
+        List<Experiment> experiments = experimentRepository.findAllByOrderByCreatedAtDesc();
+        LOGGER.debug("Found {} experiments", experiments.size());
+        return experiments;
+    }
+
+    /**
+     * Retrieves all experiments with the specified status.
+     *
+     * @param status the experiment status to filter by
+     * @return a list of experiments with the specified status, ordered by creation date descending,
+     *     or an empty list if none found
+     */
+    public List<Experiment> findByStatus(ExperimentStatus status) {
+        LOGGER.debug("Retrieving experiments with status: {}", status);
+        List<Experiment> experiments =
+                experimentRepository.findByStatusOrderByCreatedAtDesc(status);
+        LOGGER.debug("Found {} experiments with status: {}", experiments.size(), status);
+        return experiments;
+    }
+
+    /**
+     * Retrieves an experiment by its identifier.
+     *
+     * @param id the unique identifier of the experiment
+     * @return the experiment with the specified identifier
+     * @throws EntityNotFoundException if no experiment exists with the given identifier
+     */
+    public Experiment findById(Long id) {
+        LOGGER.debug("Retrieving experiment with id: {}", id);
+        return experimentRepository
+                .findById(id)
+                .orElseThrow(
+                        () -> {
+                            LOGGER.warn("Experiment not found with id: {}", id);
+                            return new EntityNotFoundException("Experiment not found: " + id);
+                        });
+    }
+
+    /**
+     * Creates a new experiment from the provided request.
+     *
+     * <p>The experiment is created with DRAFT status. If a task template ID is provided, the
+     * template is validated to exist before associating it with the experiment.
+     *
+     * @param request the experiment creation request containing all required fields
+     * @return the newly created experiment with generated identifier
+     * @throws EntityNotFoundException if the specified task template does not exist
+     * @throws IllegalArgumentException if the configuration is invalid
+     */
+    @Transactional
+    public Experiment create(ExperimentRequest request) {
+        LOGGER.info("Creating new experiment with name: {}", request.getName());
+
+        // Validate configuration
+        validateConfig(request.getConfig());
+
+        // Look up task template if provided
+        TaskTemplate taskTemplate = null;
+        if (request.getTaskTemplateId() != null) {
+            taskTemplate = findTaskTemplate(request.getTaskTemplateId());
+        }
+
+        // Serialise config to JSON
+        String configJson = serialiseConfig(request.getConfig());
+
+        Experiment experiment =
+                Experiment.builder()
+                        .name(request.getName())
+                        .taskTemplate(taskTemplate)
+                        .status(ExperimentStatus.DRAFT)
+                        .config(configJson)
+                        .build();
+
+        Experiment savedExperiment = experimentRepository.save(experiment);
+        LOGGER.info("Created experiment with id: {}", savedExperiment.getId());
+        return savedExperiment;
+    }
+
+    /**
+     * Updates an existing experiment with the provided request data.
+     *
+     * <p>Only experiments in DRAFT status can be updated. Attempting to update an experiment in any
+     * other status will result in an IllegalStateException.
+     *
+     * @param id the identifier of the experiment to update
+     * @param request the experiment update request containing updated fields
+     * @return the updated experiment
+     * @throws EntityNotFoundException if no experiment exists with the given identifier
+     * @throws IllegalStateException if the experiment is not in DRAFT status
+     * @throws IllegalArgumentException if the configuration is invalid
+     */
+    @Transactional
+    public Experiment update(Long id, ExperimentRequest request) {
+        LOGGER.info("Updating experiment with id: {}", id);
+
+        Experiment existingExperiment = findById(id);
+
+        // Only DRAFT experiments can be updated
+        if (existingExperiment.getStatus() != ExperimentStatus.DRAFT) {
+            LOGGER.warn(
+                    "Cannot update experiment {} with status: {}",
+                    id,
+                    existingExperiment.getStatus());
+            throw new IllegalStateException(
+                    "Cannot update experiment with status: " + existingExperiment.getStatus());
+        }
+
+        // Validate configuration
+        validateConfig(request.getConfig());
+
+        // Look up task template if provided
+        TaskTemplate taskTemplate = null;
+        if (request.getTaskTemplateId() != null) {
+            taskTemplate = findTaskTemplate(request.getTaskTemplateId());
+        }
+
+        // Serialise config to JSON
+        String configJson = serialiseConfig(request.getConfig());
+
+        existingExperiment.setName(request.getName());
+        existingExperiment.setTaskTemplate(taskTemplate);
+        existingExperiment.setConfig(configJson);
+
+        Experiment updatedExperiment = experimentRepository.save(existingExperiment);
+        LOGGER.info("Updated experiment with id: {}", updatedExperiment.getId());
+        return updatedExperiment;
+    }
+
+    /**
+     * Deletes an experiment by its identifier.
+     *
+     * <p>Running experiments cannot be deleted. Deleting an experiment will cascade delete all
+     * associated experiment runs.
+     *
+     * @param id the identifier of the experiment to delete
+     * @throws EntityNotFoundException if no experiment exists with the given identifier
+     * @throws IllegalStateException if the experiment is currently running
+     */
+    @Transactional
+    public void delete(Long id) {
+        LOGGER.info("Deleting experiment with id: {}", id);
+
+        Experiment experiment = findById(id);
+
+        // Cannot delete running experiments
+        if (experiment.getStatus() == ExperimentStatus.RUNNING) {
+            LOGGER.warn("Cannot delete running experiment with id: {}", id);
+            throw new IllegalStateException("Cannot delete a running experiment");
+        }
+
+        experimentRepository.delete(experiment);
+        LOGGER.info("Deleted experiment with id: {}", id);
+    }
+
+    /**
+     * Updates the status of an experiment.
+     *
+     * <p>This method is primarily used by the ExperimentExecutorService to update experiment status
+     * during execution. No validation of status transitions is performed here; the executor is
+     * responsible for ensuring valid transitions.
+     *
+     * @param id the identifier of the experiment to update
+     * @param status the new status to set
+     * @throws EntityNotFoundException if no experiment exists with the given identifier
+     */
+    @Transactional
+    public void updateStatus(Long id, ExperimentStatus status) {
+        LOGGER.info("Updating experiment {} status to: {}", id, status);
+
+        Experiment experiment = findById(id);
+        experiment.setStatus(status);
+        experimentRepository.save(experiment);
+
+        LOGGER.info("Updated experiment {} status to: {}", id, status);
+    }
+
+    /**
+     * Calculates the total number of runs for an experiment configuration.
+     *
+     * <p>The formula is: {@code models × max(embeddingModels, 1) × iterations}
+     *
+     * <p>If no embedding models are specified (non-RAG mode), the embedding count is treated as 1.
+     *
+     * @param config the experiment configuration
+     * @return the total number of runs that will be executed
+     */
+    public int calculateTotalRuns(ExperimentConfig config) {
+        int modelCount = config.getModels() != null ? config.getModels().size() : 0;
+        int embeddingCount =
+                config.getEmbeddingModels() != null && !config.getEmbeddingModels().isEmpty()
+                        ? config.getEmbeddingModels().size()
+                        : 1;
+        int iterations = config.getIterations() != null ? config.getIterations() : 1;
+
+        int totalRuns = modelCount * embeddingCount * iterations;
+        LOGGER.debug(
+                "Calculated total runs: {} (models={}, embeddings={}, iterations={})",
+                totalRuns,
+                modelCount,
+                embeddingCount,
+                iterations);
+        return totalRuns;
+    }
+
+    /**
+     * Parses the JSON configuration string into an ExperimentConfig object.
+     *
+     * @param configJson the JSON string to parse
+     * @return the parsed ExperimentConfig object
+     * @throws IllegalArgumentException if the JSON cannot be parsed
+     */
+    public ExperimentConfig parseConfig(String configJson) {
+        if (configJson == null || configJson.isEmpty()) {
+            LOGGER.debug("Config JSON is null or empty");
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(configJson, ExperimentConfig.class);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Failed to parse experiment config JSON: {}", e.getMessage());
+            throw new IllegalArgumentException("Invalid experiment configuration JSON", e);
+        }
+    }
+
+    /**
+     * Validates the experiment configuration.
+     *
+     * <p>Checks that:
+     *
+     * <ul>
+     *   <li>At least one model is specified
+     *   <li>Iterations is at least 1
+     *   <li>If context mode is RAG, embedding models and document ID are provided
+     * </ul>
+     *
+     * @param config the configuration to validate
+     * @throws IllegalArgumentException if the configuration is invalid
+     */
+    private void validateConfig(ExperimentConfig config) {
+        if (config.getModels() == null || config.getModels().isEmpty()) {
+            throw new IllegalArgumentException("At least one model must be selected");
+        }
+
+        if (config.getIterations() != null && config.getIterations() < 1) {
+            throw new IllegalArgumentException("Iterations must be at least 1");
+        }
+
+        // Validate RAG-specific requirements
+        if ("RAG".equalsIgnoreCase(config.getContextMode())) {
+            if (config.getEmbeddingModels() == null || config.getEmbeddingModels().isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Embedding models must be specified for RAG context mode");
+            }
+            if (config.getDocumentId() == null) {
+                throw new IllegalArgumentException(
+                        "Document ID must be specified for RAG context mode");
+            }
+        }
+
+        LOGGER.debug("Configuration validation passed");
+    }
+
+    /**
+     * Finds a task template by ID.
+     *
+     * @param taskTemplateId the ID of the task template to find
+     * @return the task template
+     * @throws EntityNotFoundException if the task template does not exist
+     */
+    private TaskTemplate findTaskTemplate(Long taskTemplateId) {
+        return taskTemplateRepository
+                .findById(taskTemplateId)
+                .orElseThrow(
+                        () -> {
+                            LOGGER.warn("Task template not found with id: {}", taskTemplateId);
+                            return new EntityNotFoundException(
+                                    "Task template not found: " + taskTemplateId);
+                        });
+    }
+
+    /**
+     * Serialises an ExperimentConfig to JSON.
+     *
+     * @param config the configuration to serialise
+     * @return the JSON string representation
+     * @throws IllegalArgumentException if serialisation fails
+     */
+    private String serialiseConfig(ExperimentConfig config) {
+        try {
+            return objectMapper.writeValueAsString(config);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Failed to serialise experiment config: {}", e.getMessage());
+            throw new IllegalArgumentException("Failed to serialise experiment configuration", e);
+        }
+    }
+}

--- a/backend/src/test/java/com/locallab/service/AnalyticsServiceTest.java
+++ b/backend/src/test/java/com/locallab/service/AnalyticsServiceTest.java
@@ -1,0 +1,782 @@
+package com.locallab.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.locallab.dto.LeaderboardData;
+import com.locallab.dto.LeaderboardEntry;
+import com.locallab.dto.LeaderboardFilter;
+import com.locallab.dto.ModelMetrics;
+import com.locallab.dto.RunSummary;
+import com.locallab.model.EmbeddingModel;
+import com.locallab.model.Experiment;
+import com.locallab.model.ExperimentRun;
+import com.locallab.model.enums.ExperimentStatus;
+import com.locallab.model.enums.RunStatus;
+import com.locallab.repository.ExperimentRunRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+
+/**
+ * Unit tests for {@link AnalyticsService}.
+ *
+ * <p>Uses Mockito to mock the {@link ExperimentRunRepository} dependency. Tests cover leaderboard
+ * generation, model metrics calculation, model comparison, and various edge cases.
+ *
+ * @see AnalyticsService
+ * @see ExperimentRunRepository
+ */
+@ExtendWith(MockitoExtension.class)
+class AnalyticsServiceTest {
+
+    @Mock private ExperimentRunRepository experimentRunRepository;
+
+    @InjectMocks private AnalyticsService analyticsService;
+
+    private Experiment experiment;
+    private EmbeddingModel embeddingModel;
+    private ExperimentRun successRun1;
+    private ExperimentRun successRun2;
+    private ExperimentRun successRun3;
+    private ExperimentRun failedRun;
+    private ExperimentRun pendingRun;
+
+    @BeforeEach
+    void setUp() {
+        experiment =
+                Experiment.builder()
+                        .id(1L)
+                        .name("Test Experiment")
+                        .status(ExperimentStatus.COMPLETED)
+                        .createdAt(LocalDateTime.now())
+                        .build();
+
+        embeddingModel =
+                EmbeddingModel.builder()
+                        .id(1L)
+                        .name("Nomic Embed Text")
+                        .ollamaModelName("nomic-embed-text")
+                        .dimensions(768)
+                        .createdAt(LocalDateTime.now())
+                        .build();
+
+        successRun1 =
+                ExperimentRun.builder()
+                        .id(1L)
+                        .experiment(experiment)
+                        .modelName("qwen2.5-coder:7b")
+                        .iteration(1)
+                        .status(RunStatus.SUCCESS)
+                        .durationMs(2500L)
+                        .tokensPerSecond(45.5)
+                        .timeToFirstTokenMs(120L)
+                        .timestamp(LocalDateTime.now())
+                        .build();
+
+        successRun2 =
+                ExperimentRun.builder()
+                        .id(2L)
+                        .experiment(experiment)
+                        .modelName("qwen2.5-coder:7b")
+                        .iteration(2)
+                        .status(RunStatus.SUCCESS)
+                        .durationMs(2200L)
+                        .tokensPerSecond(50.0)
+                        .timeToFirstTokenMs(100L)
+                        .timestamp(LocalDateTime.now())
+                        .build();
+
+        successRun3 =
+                ExperimentRun.builder()
+                        .id(3L)
+                        .experiment(experiment)
+                        .modelName("codellama:7b")
+                        .iteration(1)
+                        .status(RunStatus.SUCCESS)
+                        .durationMs(3000L)
+                        .tokensPerSecond(35.0)
+                        .timeToFirstTokenMs(150L)
+                        .timestamp(LocalDateTime.now())
+                        .build();
+
+        failedRun =
+                ExperimentRun.builder()
+                        .id(4L)
+                        .experiment(experiment)
+                        .modelName("qwen2.5-coder:7b")
+                        .iteration(3)
+                        .status(RunStatus.FAILED)
+                        .errorMessage("Connection timeout")
+                        .timestamp(LocalDateTime.now())
+                        .build();
+
+        pendingRun =
+                ExperimentRun.builder()
+                        .id(5L)
+                        .experiment(experiment)
+                        .modelName("codellama:7b")
+                        .iteration(2)
+                        .status(RunStatus.PENDING)
+                        .timestamp(LocalDateTime.now())
+                        .build();
+    }
+
+    @Nested
+    @DisplayName("getLeaderboard Tests")
+    class GetLeaderboardTests {
+
+        @Test
+        @DisplayName("Should return empty leaderboard when no runs exist")
+        void shouldReturnEmptyLeaderboardWhenNoRunsExist() {
+            LeaderboardFilter filter = LeaderboardFilter.builder().build();
+            when(experimentRunRepository.findAll()).thenReturn(Collections.emptyList());
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertTrue(result.getEntries().isEmpty());
+            assertEquals(0, result.getTotalRuns());
+            verify(experimentRunRepository).findAll();
+        }
+
+        @Test
+        @DisplayName("Should generate leaderboard with correct metrics")
+        void shouldGenerateLeaderboardWithCorrectMetrics() {
+            LeaderboardFilter filter = LeaderboardFilter.builder().build();
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Arrays.asList(successRun1, successRun2, successRun3, failedRun));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertEquals(4, result.getTotalRuns());
+            assertEquals(2, result.getEntries().size());
+
+            // Find qwen entry
+            LeaderboardEntry qwenEntry =
+                    result.getEntries().stream()
+                            .filter(e -> "qwen2.5-coder:7b".equals(e.getModelName()))
+                            .findFirst()
+                            .orElseThrow();
+
+            assertEquals(3, qwenEntry.getRunCount());
+            assertEquals(2, qwenEntry.getSuccessCount());
+            assertEquals(47.75, qwenEntry.getAvgTokensPerSecond(), 0.01);
+            assertEquals(45.5, qwenEntry.getMinTokensPerSecond(), 0.01);
+            assertEquals(50.0, qwenEntry.getMaxTokensPerSecond(), 0.01);
+        }
+
+        @Test
+        @DisplayName("Should filter by experiment ID")
+        void shouldFilterByExperimentId() {
+            LeaderboardFilter filter = LeaderboardFilter.builder().experimentId(1L).build();
+            when(experimentRunRepository.findByExperimentIdOrderByIterationAsc(1L))
+                    .thenReturn(Arrays.asList(successRun1, successRun2));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertEquals(2, result.getTotalRuns());
+            verify(experimentRunRepository).findByExperimentIdOrderByIterationAsc(1L);
+        }
+
+        @Test
+        @DisplayName("Should filter by model name")
+        void shouldFilterByModelName() {
+            LeaderboardFilter filter =
+                    LeaderboardFilter.builder().modelName("qwen2.5-coder:7b").build();
+            when(experimentRunRepository.findByModelName("qwen2.5-coder:7b"))
+                    .thenReturn(Arrays.asList(successRun1, successRun2, failedRun));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertEquals(3, result.getTotalRuns());
+            assertEquals(1, result.getEntries().size());
+            assertEquals("qwen2.5-coder:7b", result.getEntries().get(0).getModelName());
+        }
+
+        @Test
+        @DisplayName("Should filter by embedding model")
+        void shouldFilterByEmbeddingModel() {
+            ExperimentRun runWithEmbedding =
+                    ExperimentRun.builder()
+                            .id(10L)
+                            .experiment(experiment)
+                            .modelName("qwen2.5-coder:7b")
+                            .embeddingModel(embeddingModel)
+                            .iteration(1)
+                            .status(RunStatus.SUCCESS)
+                            .durationMs(2000L)
+                            .tokensPerSecond(40.0)
+                            .timestamp(LocalDateTime.now())
+                            .build();
+
+            LeaderboardFilter filter =
+                    LeaderboardFilter.builder().embeddingModel("nomic-embed-text").build();
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Arrays.asList(successRun1, runWithEmbedding));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertEquals(1, result.getTotalRuns());
+        }
+
+        @Test
+        @DisplayName("Should sort by TPS descending by default")
+        void shouldSortByTpsDescendingByDefault() {
+            LeaderboardFilter filter = LeaderboardFilter.builder().build();
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Arrays.asList(successRun1, successRun2, successRun3));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertEquals(2, result.getEntries().size());
+            // qwen has higher TPS (47.75) than codellama (35.0)
+            assertEquals("qwen2.5-coder:7b", result.getEntries().get(0).getModelName());
+            assertEquals("codellama:7b", result.getEntries().get(1).getModelName());
+        }
+
+        @Test
+        @DisplayName("Should sort by duration ascending")
+        void shouldSortByDurationAscending() {
+            LeaderboardFilter filter =
+                    LeaderboardFilter.builder().sortBy("duration").sortOrder("asc").build();
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Arrays.asList(successRun1, successRun2, successRun3));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertEquals(2, result.getEntries().size());
+            // qwen has lower avg duration (2350) than codellama (3000)
+            assertEquals("qwen2.5-coder:7b", result.getEntries().get(0).getModelName());
+            assertEquals("codellama:7b", result.getEntries().get(1).getModelName());
+        }
+
+        @Test
+        @DisplayName("Should sort by success rate descending")
+        void shouldSortBySuccessRateDescending() {
+            LeaderboardFilter filter =
+                    LeaderboardFilter.builder().sortBy("successRate").sortOrder("desc").build();
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Arrays.asList(successRun1, successRun2, successRun3, failedRun));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertEquals(2, result.getEntries().size());
+            // codellama has 100% success rate, qwen has 66.67%
+            assertEquals("codellama:7b", result.getEntries().get(0).getModelName());
+            assertEquals("qwen2.5-coder:7b", result.getEntries().get(1).getModelName());
+        }
+
+        @Test
+        @DisplayName("Should sort by TTFT")
+        void shouldSortByTtft() {
+            LeaderboardFilter filter =
+                    LeaderboardFilter.builder().sortBy("ttft").sortOrder("asc").build();
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Arrays.asList(successRun1, successRun2, successRun3));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertEquals(2, result.getEntries().size());
+            // qwen has lower avg TTFT (110) than codellama (150)
+            assertEquals("qwen2.5-coder:7b", result.getEntries().get(0).getModelName());
+        }
+
+        @Test
+        @DisplayName("Should calculate correct success rate")
+        void shouldCalculateCorrectSuccessRate() {
+            LeaderboardFilter filter = LeaderboardFilter.builder().build();
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Arrays.asList(successRun1, successRun2, failedRun));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            LeaderboardEntry entry = result.getEntries().get(0);
+            assertEquals(3, entry.getRunCount());
+            assertEquals(2, entry.getSuccessCount());
+            assertEquals(66.67, entry.getSuccessRate(), 0.01);
+        }
+
+        @Test
+        @DisplayName("Should handle runs with null metrics")
+        void shouldHandleRunsWithNullMetrics() {
+            ExperimentRun runWithNullMetrics =
+                    ExperimentRun.builder()
+                            .id(10L)
+                            .experiment(experiment)
+                            .modelName("test-model")
+                            .iteration(1)
+                            .status(RunStatus.SUCCESS)
+                            .timestamp(LocalDateTime.now())
+                            .build();
+
+            LeaderboardFilter filter = LeaderboardFilter.builder().build();
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Collections.singletonList(runWithNullMetrics));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertEquals(1, result.getEntries().size());
+            LeaderboardEntry entry = result.getEntries().get(0);
+            assertNull(entry.getAvgTokensPerSecond());
+            assertNull(entry.getMinTokensPerSecond());
+            assertNull(entry.getAvgDurationMs());
+        }
+
+        @Test
+        @DisplayName("Should only include successful runs in entry statistics")
+        void shouldOnlyIncludeSuccessfulRunsInStatistics() {
+            LeaderboardFilter filter = LeaderboardFilter.builder().build();
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Arrays.asList(successRun1, failedRun, pendingRun));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            // Failed and pending runs should not contribute to the leaderboard entries
+            // since we only group successful runs
+            assertEquals(1, result.getEntries().size());
+            assertEquals("qwen2.5-coder:7b", result.getEntries().get(0).getModelName());
+        }
+    }
+
+    @Nested
+    @DisplayName("getModelMetrics Tests")
+    class GetModelMetricsTests {
+
+        @Test
+        @DisplayName("Should return model metrics when runs exist")
+        void shouldReturnModelMetricsWhenRunsExist() {
+            when(experimentRunRepository.findByModelName("qwen2.5-coder:7b"))
+                    .thenReturn(Arrays.asList(successRun1, successRun2, failedRun));
+
+            ModelMetrics result = analyticsService.getModelMetrics("qwen2.5-coder:7b", null);
+
+            assertNotNull(result);
+            assertEquals("qwen2.5-coder:7b", result.getModelName());
+            assertEquals(3, result.getTotalRuns());
+            assertEquals(2, result.getSuccessfulRuns());
+            assertEquals(1, result.getFailedRuns());
+            assertEquals(66.67, result.getSuccessRate(), 0.01);
+            assertEquals(47.75, result.getAvgTokensPerSecond(), 0.01);
+            assertEquals(2350.0, result.getAvgDurationMs(), 0.01);
+            assertEquals(110.0, result.getAvgTimeToFirstTokenMs(), 0.01);
+        }
+
+        @Test
+        @DisplayName("Should throw EntityNotFoundException when no runs found")
+        void shouldThrowEntityNotFoundExceptionWhenNoRunsFound() {
+            when(experimentRunRepository.findByModelName("nonexistent-model"))
+                    .thenReturn(Collections.emptyList());
+
+            EntityNotFoundException exception =
+                    assertThrows(
+                            EntityNotFoundException.class,
+                            () -> analyticsService.getModelMetrics("nonexistent-model", null));
+
+            assertEquals("No runs found for model: nonexistent-model", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should filter by experiment ID when provided")
+        void shouldFilterByExperimentIdWhenProvided() {
+            when(experimentRunRepository.findByExperimentIdAndModelName(1L, "qwen2.5-coder:7b"))
+                    .thenReturn(Arrays.asList(successRun1, successRun2));
+
+            ModelMetrics result = analyticsService.getModelMetrics("qwen2.5-coder:7b", 1L);
+
+            assertNotNull(result);
+            assertEquals(2, result.getTotalRuns());
+            verify(experimentRunRepository).findByExperimentIdAndModelName(1L, "qwen2.5-coder:7b");
+        }
+
+        @Test
+        @DisplayName("Should group runs by iteration")
+        void shouldGroupRunsByIteration() {
+            when(experimentRunRepository.findByModelName("qwen2.5-coder:7b"))
+                    .thenReturn(Arrays.asList(successRun1, successRun2, failedRun));
+
+            ModelMetrics result = analyticsService.getModelMetrics("qwen2.5-coder:7b", null);
+
+            assertNotNull(result.getRunsByIteration());
+            assertEquals(3, result.getRunsByIteration().size());
+
+            // Iteration 1
+            List<RunSummary> iteration1 = result.getRunsByIteration().get(1);
+            assertNotNull(iteration1);
+            assertEquals(1, iteration1.size());
+            assertEquals(1L, iteration1.get(0).getId());
+            assertEquals(RunStatus.SUCCESS, iteration1.get(0).getStatus());
+
+            // Iteration 2
+            List<RunSummary> iteration2 = result.getRunsByIteration().get(2);
+            assertNotNull(iteration2);
+            assertEquals(1, iteration2.size());
+            assertEquals(2L, iteration2.get(0).getId());
+
+            // Iteration 3 (failed)
+            List<RunSummary> iteration3 = result.getRunsByIteration().get(3);
+            assertNotNull(iteration3);
+            assertEquals(1, iteration3.size());
+            assertEquals(RunStatus.FAILED, iteration3.get(0).getStatus());
+        }
+
+        @Test
+        @DisplayName("Should handle runs with null metrics gracefully")
+        void shouldHandleRunsWithNullMetricsGracefully() {
+            ExperimentRun runWithNullMetrics =
+                    ExperimentRun.builder()
+                            .id(10L)
+                            .experiment(experiment)
+                            .modelName("test-model")
+                            .iteration(1)
+                            .status(RunStatus.SUCCESS)
+                            .timestamp(LocalDateTime.now())
+                            .build();
+
+            when(experimentRunRepository.findByModelName("test-model"))
+                    .thenReturn(Collections.singletonList(runWithNullMetrics));
+
+            ModelMetrics result = analyticsService.getModelMetrics("test-model", null);
+
+            assertNotNull(result);
+            assertEquals(1, result.getTotalRuns());
+            assertEquals(1, result.getSuccessfulRuns());
+            assertNull(result.getAvgTokensPerSecond());
+            assertNull(result.getAvgDurationMs());
+            assertNull(result.getAvgTimeToFirstTokenMs());
+        }
+
+        @Test
+        @DisplayName("Should calculate averages only from successful runs")
+        void shouldCalculateAveragesOnlyFromSuccessfulRuns() {
+            when(experimentRunRepository.findByModelName("qwen2.5-coder:7b"))
+                    .thenReturn(Arrays.asList(successRun1, successRun2, failedRun));
+
+            ModelMetrics result = analyticsService.getModelMetrics("qwen2.5-coder:7b", null);
+
+            // avgTokensPerSecond should be (45.5 + 50.0) / 2 = 47.75
+            assertEquals(47.75, result.getAvgTokensPerSecond(), 0.01);
+
+            // Failed run should not contribute to averages
+            assertEquals(2, result.getSuccessfulRuns());
+        }
+
+        @Test
+        @DisplayName("Should handle all failed runs")
+        void shouldHandleAllFailedRuns() {
+            ExperimentRun failedRun2 =
+                    ExperimentRun.builder()
+                            .id(20L)
+                            .experiment(experiment)
+                            .modelName("failing-model")
+                            .iteration(1)
+                            .status(RunStatus.FAILED)
+                            .errorMessage("Error")
+                            .timestamp(LocalDateTime.now())
+                            .build();
+
+            when(experimentRunRepository.findByModelName("failing-model"))
+                    .thenReturn(Collections.singletonList(failedRun2));
+
+            ModelMetrics result = analyticsService.getModelMetrics("failing-model", null);
+
+            assertNotNull(result);
+            assertEquals(1, result.getTotalRuns());
+            assertEquals(0, result.getSuccessfulRuns());
+            assertEquals(1, result.getFailedRuns());
+            assertEquals(0.0, result.getSuccessRate(), 0.01);
+            assertNull(result.getAvgTokensPerSecond());
+        }
+    }
+
+    @Nested
+    @DisplayName("compareModels Tests")
+    class CompareModelsTests {
+
+        @Test
+        @DisplayName("Should return empty map when no runs exist")
+        void shouldReturnEmptyMapWhenNoRunsExist() {
+            when(experimentRunRepository.findByExperimentIdOrderByIterationAsc(1L))
+                    .thenReturn(Collections.emptyList());
+
+            Map<String, ModelMetrics> result = analyticsService.compareModels(1L);
+
+            assertNotNull(result);
+            assertTrue(result.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should return metrics for all models in experiment")
+        void shouldReturnMetricsForAllModelsInExperiment() {
+            when(experimentRunRepository.findByExperimentIdOrderByIterationAsc(1L))
+                    .thenReturn(Arrays.asList(successRun1, successRun2, successRun3));
+            when(experimentRunRepository.findByExperimentIdAndModelName(1L, "qwen2.5-coder:7b"))
+                    .thenReturn(Arrays.asList(successRun1, successRun2));
+            when(experimentRunRepository.findByExperimentIdAndModelName(1L, "codellama:7b"))
+                    .thenReturn(Collections.singletonList(successRun3));
+
+            Map<String, ModelMetrics> result = analyticsService.compareModels(1L);
+
+            assertNotNull(result);
+            assertEquals(2, result.size());
+            assertTrue(result.containsKey("qwen2.5-coder:7b"));
+            assertTrue(result.containsKey("codellama:7b"));
+
+            ModelMetrics qwenMetrics = result.get("qwen2.5-coder:7b");
+            assertEquals(2, qwenMetrics.getTotalRuns());
+            assertEquals(47.75, qwenMetrics.getAvgTokensPerSecond(), 0.01);
+
+            ModelMetrics llamaMetrics = result.get("codellama:7b");
+            assertEquals(1, llamaMetrics.getTotalRuns());
+            assertEquals(35.0, llamaMetrics.getAvgTokensPerSecond(), 0.01);
+        }
+
+        @Test
+        @DisplayName("Should handle single model experiment")
+        void shouldHandleSingleModelExperiment() {
+            when(experimentRunRepository.findByExperimentIdOrderByIterationAsc(1L))
+                    .thenReturn(Arrays.asList(successRun1, successRun2));
+            when(experimentRunRepository.findByExperimentIdAndModelName(1L, "qwen2.5-coder:7b"))
+                    .thenReturn(Arrays.asList(successRun1, successRun2));
+
+            Map<String, ModelMetrics> result = analyticsService.compareModels(1L);
+
+            assertNotNull(result);
+            assertEquals(1, result.size());
+            assertTrue(result.containsKey("qwen2.5-coder:7b"));
+        }
+
+        @Test
+        @DisplayName("Should include failed and pending runs in model list")
+        void shouldIncludeFailedAndPendingRunsInModelList() {
+            when(experimentRunRepository.findByExperimentIdOrderByIterationAsc(1L))
+                    .thenReturn(Arrays.asList(successRun1, failedRun, pendingRun));
+            when(experimentRunRepository.findByExperimentIdAndModelName(1L, "qwen2.5-coder:7b"))
+                    .thenReturn(Arrays.asList(successRun1, failedRun));
+            when(experimentRunRepository.findByExperimentIdAndModelName(1L, "codellama:7b"))
+                    .thenReturn(Collections.singletonList(pendingRun));
+
+            Map<String, ModelMetrics> result = analyticsService.compareModels(1L);
+
+            assertNotNull(result);
+            assertEquals(2, result.size());
+
+            ModelMetrics qwenMetrics = result.get("qwen2.5-coder:7b");
+            assertEquals(2, qwenMetrics.getTotalRuns());
+            assertEquals(1, qwenMetrics.getSuccessfulRuns());
+            assertEquals(1, qwenMetrics.getFailedRuns());
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge Cases")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("Should handle filter with both experiment and model name")
+        void shouldHandleFilterWithBothExperimentAndModelName() {
+            LeaderboardFilter filter =
+                    LeaderboardFilter.builder()
+                            .experimentId(1L)
+                            .modelName("qwen2.5-coder:7b")
+                            .build();
+
+            when(experimentRunRepository.findByExperimentIdOrderByIterationAsc(1L))
+                    .thenReturn(Arrays.asList(successRun1, successRun2, successRun3));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            // Should only include qwen runs
+            assertEquals(2, result.getTotalRuns());
+            assertEquals(1, result.getEntries().size());
+            assertEquals("qwen2.5-coder:7b", result.getEntries().get(0).getModelName());
+        }
+
+        @Test
+        @DisplayName("Should handle null sort parameters gracefully")
+        void shouldHandleNullSortParametersGracefully() {
+            LeaderboardFilter filter =
+                    LeaderboardFilter.builder().sortBy(null).sortOrder(null).build();
+
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Arrays.asList(successRun1, successRun3));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            // Should default to TPS descending
+            assertEquals("qwen2.5-coder:7b", result.getEntries().get(0).getModelName());
+        }
+
+        @Test
+        @DisplayName("Should handle empty model name filter")
+        void shouldHandleEmptyModelNameFilter() {
+            LeaderboardFilter filter = LeaderboardFilter.builder().modelName("").build();
+
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Arrays.asList(successRun1, successRun3));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertEquals(2, result.getTotalRuns());
+        }
+
+        @Test
+        @DisplayName("Should handle whitespace model name filter")
+        void shouldHandleWhitespaceModelNameFilter() {
+            LeaderboardFilter filter = LeaderboardFilter.builder().modelName("   ").build();
+
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Arrays.asList(successRun1, successRun3));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertEquals(2, result.getTotalRuns());
+        }
+
+        @Test
+        @DisplayName("Should handle runs with same TPS for sorting")
+        void shouldHandleRunsWithSameTpsForSorting() {
+            ExperimentRun runSameTps =
+                    ExperimentRun.builder()
+                            .id(10L)
+                            .experiment(experiment)
+                            .modelName("same-tps-model")
+                            .iteration(1)
+                            .status(RunStatus.SUCCESS)
+                            .tokensPerSecond(45.5)
+                            .timestamp(LocalDateTime.now())
+                            .build();
+
+            LeaderboardFilter filter = LeaderboardFilter.builder().build();
+            when(experimentRunRepository.findAll())
+                    .thenReturn(Arrays.asList(successRun1, runSameTps));
+
+            LeaderboardData result = analyticsService.getLeaderboard(filter);
+
+            assertNotNull(result);
+            assertEquals(2, result.getEntries().size());
+        }
+
+        @Test
+        @DisplayName("Should handle very large numbers in metrics")
+        void shouldHandleVeryLargeNumbersInMetrics() {
+            ExperimentRun largeMetricsRun =
+                    ExperimentRun.builder()
+                            .id(10L)
+                            .experiment(experiment)
+                            .modelName("large-metrics-model")
+                            .iteration(1)
+                            .status(RunStatus.SUCCESS)
+                            .durationMs(Long.MAX_VALUE / 2)
+                            .tokensPerSecond(Double.MAX_VALUE / 2)
+                            .timeToFirstTokenMs(Long.MAX_VALUE / 2)
+                            .timestamp(LocalDateTime.now())
+                            .build();
+
+            when(experimentRunRepository.findByModelName("large-metrics-model"))
+                    .thenReturn(Collections.singletonList(largeMetricsRun));
+
+            ModelMetrics result = analyticsService.getModelMetrics("large-metrics-model", null);
+
+            assertNotNull(result);
+            assertNotNull(result.getAvgTokensPerSecond());
+            assertNotNull(result.getAvgDurationMs());
+        }
+
+        @Test
+        @DisplayName("Should correctly convert RunSummary from ExperimentRun")
+        void shouldCorrectlyConvertRunSummaryFromExperimentRun() {
+            when(experimentRunRepository.findByModelName("qwen2.5-coder:7b"))
+                    .thenReturn(Collections.singletonList(successRun1));
+
+            ModelMetrics result = analyticsService.getModelMetrics("qwen2.5-coder:7b", null);
+
+            RunSummary summary = result.getRunsByIteration().get(1).get(0);
+            assertEquals(1L, summary.getId());
+            assertEquals(RunStatus.SUCCESS, summary.getStatus());
+            assertEquals(2500L, summary.getDurationMs());
+            assertEquals(45.5, summary.getTokensPerSecond(), 0.01);
+        }
+    }
+
+    @Nested
+    @DisplayName("RunSummary Conversion Tests")
+    class RunSummaryConversionTests {
+
+        @Test
+        @DisplayName("Should preserve all fields when converting to RunSummary")
+        void shouldPreserveAllFieldsWhenConvertingToRunSummary() {
+            when(experimentRunRepository.findByModelName("qwen2.5-coder:7b"))
+                    .thenReturn(Collections.singletonList(successRun1));
+
+            ModelMetrics result = analyticsService.getModelMetrics("qwen2.5-coder:7b", null);
+
+            List<RunSummary> summaries = result.getRunsByIteration().get(1);
+            assertNotNull(summaries);
+            assertEquals(1, summaries.size());
+
+            RunSummary summary = summaries.get(0);
+            assertEquals(successRun1.getId(), summary.getId());
+            assertEquals(successRun1.getStatus(), summary.getStatus());
+            assertEquals(successRun1.getDurationMs(), summary.getDurationMs());
+            assertEquals(successRun1.getTokensPerSecond(), summary.getTokensPerSecond());
+        }
+
+        @Test
+        @DisplayName("Should handle null fields in RunSummary")
+        void shouldHandleNullFieldsInRunSummary() {
+            ExperimentRun pendingWithNulls =
+                    ExperimentRun.builder()
+                            .id(100L)
+                            .experiment(experiment)
+                            .modelName("pending-model")
+                            .iteration(1)
+                            .status(RunStatus.PENDING)
+                            .timestamp(LocalDateTime.now())
+                            .build();
+
+            when(experimentRunRepository.findByModelName("pending-model"))
+                    .thenReturn(Collections.singletonList(pendingWithNulls));
+
+            ModelMetrics result = analyticsService.getModelMetrics("pending-model", null);
+
+            RunSummary summary = result.getRunsByIteration().get(1).get(0);
+            assertEquals(100L, summary.getId());
+            assertEquals(RunStatus.PENDING, summary.getStatus());
+            assertNull(summary.getDurationMs());
+            assertNull(summary.getTokensPerSecond());
+        }
+    }
+}

--- a/backend/src/test/java/com/locallab/service/ExperimentExecutorServiceTest.java
+++ b/backend/src/test/java/com/locallab/service/ExperimentExecutorServiceTest.java
@@ -1,0 +1,1048 @@
+package com.locallab.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.locallab.dto.ExperimentConfig;
+import com.locallab.dto.ExperimentExecutionState;
+import com.locallab.dto.ExperimentProgress;
+import com.locallab.dto.Hyperparameters;
+import com.locallab.dto.RetrievedChunk;
+import com.locallab.dto.WebSocketMessage;
+import com.locallab.dto.request.GenerationRequest;
+import com.locallab.dto.response.GenerationResponse;
+import com.locallab.model.Experiment;
+import com.locallab.model.ExperimentRun;
+import com.locallab.model.SystemPrompt;
+import com.locallab.model.TaskTemplate;
+import com.locallab.model.enums.ExperimentStatus;
+import com.locallab.model.enums.RunStatus;
+import com.locallab.repository.ExperimentRepository;
+import com.locallab.repository.ExperimentRunRepository;
+import com.locallab.repository.SystemPromptRepository;
+import com.locallab.service.ExperimentExecutorService.ExperimentRunConfig;
+
+import jakarta.persistence.EntityNotFoundException;
+
+/**
+ * Unit tests for {@link ExperimentExecutorService}.
+ *
+ * <p>These tests verify the behaviour of the experiment executor service, including experiment
+ * execution, pause/resume/cancel functionality, run configuration generation, and WebSocket message
+ * publishing.
+ *
+ * @author William Stephen
+ */
+@ExtendWith(MockitoExtension.class)
+class ExperimentExecutorServiceTest {
+
+    @Mock private ExperimentRepository experimentRepository;
+    @Mock private ExperimentRunRepository experimentRunRepository;
+    @Mock private OllamaService ollamaService;
+    @Mock private RagService ragService;
+    @Mock private TaskService taskService;
+    @Mock private SystemPromptRepository systemPromptRepository;
+    @Mock private SimpMessagingTemplate messagingTemplate;
+
+    private ObjectMapper objectMapper;
+    private ExperimentExecutorService experimentExecutorService;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        experimentExecutorService =
+                new ExperimentExecutorService(
+                        experimentRepository,
+                        experimentRunRepository,
+                        ollamaService,
+                        ragService,
+                        taskService,
+                        systemPromptRepository,
+                        messagingTemplate,
+                        objectMapper);
+    }
+
+    /**
+     * Helper method to inject an execution state into the service for testing. Uses reflection to
+     * access the private executionStates map.
+     */
+    @SuppressWarnings("unchecked")
+    private void injectExecutionState(Long experimentId, ExperimentExecutionState state)
+            throws Exception {
+        Field field = ExperimentExecutorService.class.getDeclaredField("executionStates");
+        field.setAccessible(true);
+        Map<Long, ExperimentExecutionState> states =
+                (Map<Long, ExperimentExecutionState>) field.get(experimentExecutorService);
+        states.put(experimentId, state);
+    }
+
+    /**
+     * Helper method to get the execution states map for verification. Uses reflection to access the
+     * private executionStates map.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<Long, ExperimentExecutionState> getExecutionStates() throws Exception {
+        Field field = ExperimentExecutorService.class.getDeclaredField("executionStates");
+        field.setAccessible(true);
+        return (Map<Long, ExperimentExecutionState>) field.get(experimentExecutorService);
+    }
+
+    @Nested
+    @DisplayName("startExperiment")
+    class StartExperimentTests {
+
+        @Test
+        @DisplayName("should throw EntityNotFoundException when experiment not found")
+        void shouldThrowWhenExperimentNotFound() {
+            when(experimentRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(
+                    EntityNotFoundException.class,
+                    () -> experimentExecutorService.startExperiment(1L));
+        }
+
+        @Test
+        @DisplayName("should throw IllegalStateException when experiment not in DRAFT status")
+        void shouldThrowWhenNotDraft() {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.RUNNING);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            IllegalStateException exception =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> experimentExecutorService.startExperiment(1L));
+
+            assertTrue(exception.getMessage().contains("DRAFT"));
+        }
+
+        @Test
+        @DisplayName("should throw IllegalStateException for COMPLETED status")
+        void shouldThrowWhenCompleted() {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.COMPLETED);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            IllegalStateException exception =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> experimentExecutorService.startExperiment(1L));
+
+            assertTrue(exception.getMessage().contains("DRAFT"));
+            assertTrue(exception.getMessage().contains("COMPLETED"));
+        }
+
+        @Test
+        @DisplayName("should throw IllegalStateException for FAILED status")
+        void shouldThrowWhenFailed() {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.FAILED);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            IllegalStateException exception =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> experimentExecutorService.startExperiment(1L));
+
+            assertTrue(exception.getMessage().contains("DRAFT"));
+        }
+
+        @Test
+        @DisplayName("should throw IllegalStateException for PAUSED status")
+        void shouldThrowWhenPaused() {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.PAUSED);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            IllegalStateException exception =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> experimentExecutorService.startExperiment(1L));
+
+            assertTrue(exception.getMessage().contains("DRAFT"));
+        }
+    }
+
+    @Nested
+    @DisplayName("resumeExperiment")
+    class ResumeExperimentTests {
+
+        @Test
+        @DisplayName("should throw EntityNotFoundException when experiment not found")
+        void shouldThrowWhenExperimentNotFound() {
+            when(experimentRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(
+                    EntityNotFoundException.class,
+                    () -> experimentExecutorService.resumeExperiment(1L));
+        }
+
+        @Test
+        @DisplayName("should throw IllegalStateException when experiment not in PAUSED status")
+        void shouldThrowWhenNotPaused() {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.DRAFT);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            IllegalStateException exception =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> experimentExecutorService.resumeExperiment(1L));
+
+            assertTrue(exception.getMessage().contains("PAUSED"));
+        }
+
+        @Test
+        @DisplayName("should throw IllegalStateException for RUNNING status")
+        void shouldThrowWhenRunning() {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.RUNNING);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            IllegalStateException exception =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> experimentExecutorService.resumeExperiment(1L));
+
+            assertTrue(exception.getMessage().contains("PAUSED"));
+        }
+
+        @Test
+        @DisplayName("should throw IllegalStateException for COMPLETED status")
+        void shouldThrowWhenCompleted() {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.COMPLETED);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            IllegalStateException exception =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> experimentExecutorService.resumeExperiment(1L));
+
+            assertTrue(exception.getMessage().contains("PAUSED"));
+        }
+
+        @Test
+        @DisplayName("should resume successfully when experiment is paused with remaining runs")
+        void shouldResumeSuccessfully() throws Exception {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.PAUSED);
+            String configJson = objectMapper.writeValueAsString(createBasicConfig());
+            experiment.setConfig(configJson);
+            experiment.setTaskTemplate(createTaskTemplate());
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+            when(experimentRepository.save(any(Experiment.class))).thenReturn(experiment);
+
+            List<ExperimentRun> completedRuns = new ArrayList<>();
+            when(experimentRunRepository.findByExperimentIdOrderByIterationAsc(1L))
+                    .thenReturn(completedRuns);
+
+            ExperimentRun savedRun = createExperimentRun(1L, experiment);
+            when(experimentRunRepository.save(any(ExperimentRun.class))).thenReturn(savedRun);
+
+            GenerationResponse response =
+                    GenerationResponse.builder()
+                            .response("Test")
+                            .model("llama3:8b")
+                            .durationMs(1000L)
+                            .build();
+            when(ollamaService.generate(any(GenerationRequest.class))).thenReturn(response);
+
+            experimentExecutorService.resumeExperiment(1L);
+
+            Thread.sleep(500);
+
+            verify(experimentRepository, atLeastOnce()).save(any(Experiment.class));
+            verify(messagingTemplate, atLeastOnce())
+                    .convertAndSend(
+                            eq("/topic/experiments/1/progress"), any(WebSocketMessage.class));
+        }
+
+        @Test
+        @DisplayName("should mark as completed when all runs already finished")
+        void shouldCompleteWhenAllRunsFinished() throws Exception {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.PAUSED);
+            String configJson = objectMapper.writeValueAsString(createBasicConfig());
+            experiment.setConfig(configJson);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+            when(experimentRepository.save(any(Experiment.class))).thenReturn(experiment);
+
+            List<ExperimentRun> completedRuns = new ArrayList<>();
+            completedRuns.add(createExperimentRun(1L, experiment));
+            when(experimentRunRepository.findByExperimentIdOrderByIterationAsc(1L))
+                    .thenReturn(completedRuns);
+
+            experimentExecutorService.resumeExperiment(1L);
+
+            Thread.sleep(200);
+
+            ArgumentCaptor<Experiment> captor = ArgumentCaptor.forClass(Experiment.class);
+            verify(experimentRepository, atLeast(2)).save(captor.capture());
+
+            List<Experiment> savedExperiments = captor.getAllValues();
+            boolean hasCompleted =
+                    savedExperiments.stream()
+                            .anyMatch(exp -> exp.getStatus() == ExperimentStatus.COMPLETED);
+            assertTrue(hasCompleted);
+        }
+
+        @Test
+        @DisplayName("should throw IllegalStateException for FAILED status")
+        void shouldThrowWhenFailed() {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.FAILED);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            IllegalStateException exception =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> experimentExecutorService.resumeExperiment(1L));
+
+            assertTrue(exception.getMessage().contains("PAUSED"));
+        }
+    }
+
+    @Nested
+    @DisplayName("pauseExperiment")
+    class PauseExperimentTests {
+
+        @Test
+        @DisplayName("should handle pause when no active execution state")
+        void shouldHandleNoActiveState() {
+            assertDoesNotThrow(() -> experimentExecutorService.pauseExperiment(999L));
+        }
+
+        @Test
+        @DisplayName("should set paused flag when execution state exists")
+        void shouldSetPausedFlag() throws Exception {
+            ExperimentExecutionState state = new ExperimentExecutionState(1L);
+            state.setTotalRuns(5);
+            state.setCompletedRuns(2);
+            injectExecutionState(1L, state);
+
+            experimentExecutorService.pauseExperiment(1L);
+
+            assertTrue(state.isPaused());
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelExperiment")
+    class CancelExperimentTests {
+
+        @Test
+        @DisplayName("should handle cancel when no active execution state")
+        void shouldHandleNoActiveState() {
+            assertDoesNotThrow(() -> experimentExecutorService.cancelExperiment(999L));
+        }
+
+        @Test
+        @DisplayName("should set cancelled flag when execution state exists")
+        void shouldSetCancelledFlag() throws Exception {
+            ExperimentExecutionState state = new ExperimentExecutionState(1L);
+            state.setTotalRuns(5);
+            state.setCompletedRuns(2);
+            injectExecutionState(1L, state);
+
+            experimentExecutorService.cancelExperiment(1L);
+
+            assertTrue(state.isCancelled());
+        }
+    }
+
+    @Nested
+    @DisplayName("getProgress")
+    class GetProgressTests {
+
+        @Test
+        @DisplayName("should return null when experiment not executing")
+        void shouldReturnNullWhenNotExecuting() {
+            ExperimentProgress progress = experimentExecutorService.getProgress(999L);
+
+            assertNull(progress);
+        }
+
+        @Test
+        @DisplayName("should return progress when experiment is executing")
+        void shouldReturnProgressWhenExecuting() throws Exception {
+            ExperimentExecutionState state = new ExperimentExecutionState(1L);
+            state.setTotalRuns(10);
+            state.setCompletedRuns(5);
+            injectExecutionState(1L, state);
+
+            ExperimentProgress progress = experimentExecutorService.getProgress(1L);
+
+            assertNotNull(progress);
+            assertEquals(1L, progress.getExperimentId());
+            assertEquals(5, progress.getCompletedRuns());
+            assertEquals(10, progress.getTotalRuns());
+            assertEquals(50.0, progress.getProgressPercent());
+        }
+
+        @Test
+        @DisplayName("should return zero percent when total runs is zero")
+        void shouldReturnZeroPercentWhenNoRuns() throws Exception {
+            ExperimentExecutionState state = new ExperimentExecutionState(1L);
+            state.setTotalRuns(0);
+            state.setCompletedRuns(0);
+            injectExecutionState(1L, state);
+
+            ExperimentProgress progress = experimentExecutorService.getProgress(1L);
+
+            assertNotNull(progress);
+            assertEquals(0.0, progress.getProgressPercent());
+        }
+    }
+
+    @Nested
+    @DisplayName("isExecuting")
+    class IsExecutingTests {
+
+        @Test
+        @DisplayName("should return false when experiment not executing")
+        void shouldReturnFalseWhenNotExecuting() {
+            assertFalse(experimentExecutorService.isExecuting(999L));
+        }
+
+        @Test
+        @DisplayName("should return true when experiment is executing")
+        void shouldReturnTrueWhenExecuting() throws Exception {
+            ExperimentExecutionState state = new ExperimentExecutionState(1L);
+            injectExecutionState(1L, state);
+
+            assertTrue(experimentExecutorService.isExecuting(1L));
+        }
+    }
+
+    @Nested
+    @DisplayName("executeSingleRun")
+    class ExecuteSingleRunTests {
+
+        @Test
+        @DisplayName("should execute run successfully")
+        void shouldExecuteRunSuccessfully() throws Exception {
+            Experiment experiment = createExperimentWithTemplate(1L, ExperimentStatus.RUNNING);
+            ExperimentConfig config = createBasicConfig();
+            ExperimentRunConfig runConfig =
+                    ExperimentRunConfig.builder()
+                            .model("llama3:8b")
+                            .embeddingModel(null)
+                            .iteration(1)
+                            .build();
+
+            ExperimentRun savedRun = createExperimentRun(1L, experiment);
+            when(experimentRunRepository.save(any(ExperimentRun.class))).thenReturn(savedRun);
+
+            GenerationResponse response =
+                    GenerationResponse.builder()
+                            .response("Test response")
+                            .model("llama3:8b")
+                            .durationMs(1000L)
+                            .tokensPerSecond(45.5)
+                            .timeToFirstTokenMs(100L)
+                            .build();
+            when(ollamaService.generate(any(GenerationRequest.class))).thenReturn(response);
+
+            ExperimentRun result =
+                    experimentExecutorService.executeSingleRun(experiment, runConfig, config);
+
+            assertNotNull(result);
+            verify(experimentRunRepository, times(2)).save(any(ExperimentRun.class));
+            verify(ollamaService).generate(any(GenerationRequest.class));
+        }
+
+        @Test
+        @DisplayName("should handle generation failure")
+        void shouldHandleGenerationFailure() throws Exception {
+            Experiment experiment = createExperimentWithTemplate(1L, ExperimentStatus.RUNNING);
+            ExperimentConfig config = createBasicConfig();
+            ExperimentRunConfig runConfig =
+                    ExperimentRunConfig.builder()
+                            .model("llama3:8b")
+                            .embeddingModel(null)
+                            .iteration(1)
+                            .build();
+
+            ExperimentRun savedRun = createExperimentRun(1L, experiment);
+            when(experimentRunRepository.save(any(ExperimentRun.class))).thenReturn(savedRun);
+
+            when(ollamaService.generate(any(GenerationRequest.class)))
+                    .thenThrow(new RuntimeException("Generation failed"));
+
+            ExperimentRun result =
+                    experimentExecutorService.executeSingleRun(experiment, runConfig, config);
+
+            assertNotNull(result);
+            verify(experimentRunRepository, times(2)).save(any(ExperimentRun.class));
+        }
+
+        @Test
+        @DisplayName("should execute run with RAG context")
+        void shouldExecuteRunWithRagContext() throws Exception {
+            Experiment experiment = createExperimentWithTemplate(1L, ExperimentStatus.RUNNING);
+            ExperimentConfig config = createRagConfig();
+            ExperimentRunConfig runConfig =
+                    ExperimentRunConfig.builder()
+                            .model("llama3:8b")
+                            .embeddingModel("nomic-embed-text")
+                            .iteration(1)
+                            .build();
+
+            ExperimentRun savedRun = createExperimentRun(1L, experiment);
+            when(experimentRunRepository.save(any(ExperimentRun.class))).thenReturn(savedRun);
+
+            when(ragService.buildCollectionName(1L, "nomic-embed-text"))
+                    .thenReturn("doc-1-nomic-embed-text");
+
+            List<RetrievedChunk> chunks = new ArrayList<>();
+            chunks.add(RetrievedChunk.builder().content("Test chunk").build());
+            when(ragService.query(anyString(), anyString(), anyString(), anyInt()))
+                    .thenReturn(chunks);
+            when(ragService.buildContext(chunks)).thenReturn("Context:\n\n[1] Test chunk\n\n");
+
+            GenerationResponse response =
+                    GenerationResponse.builder()
+                            .response("Test response with RAG")
+                            .model("llama3:8b")
+                            .durationMs(1500L)
+                            .build();
+            when(ollamaService.generate(any(GenerationRequest.class))).thenReturn(response);
+
+            ExperimentRun result =
+                    experimentExecutorService.executeSingleRun(experiment, runConfig, config);
+
+            assertNotNull(result);
+            verify(ragService)
+                    .query(
+                            eq("doc-1-nomic-embed-text"),
+                            anyString(),
+                            eq("nomic-embed-text"),
+                            eq(5));
+            verify(ragService).buildContext(chunks);
+        }
+
+        @Test
+        @DisplayName("should execute run with system prompt")
+        void shouldExecuteRunWithSystemPrompt() throws Exception {
+            Experiment experiment = createExperimentWithTemplate(1L, ExperimentStatus.RUNNING);
+            ExperimentConfig config = createConfigWithSystemPrompt();
+            ExperimentRunConfig runConfig =
+                    ExperimentRunConfig.builder()
+                            .model("llama3:8b")
+                            .embeddingModel(null)
+                            .iteration(1)
+                            .build();
+
+            ExperimentRun savedRun = createExperimentRun(1L, experiment);
+            when(experimentRunRepository.save(any(ExperimentRun.class))).thenReturn(savedRun);
+
+            SystemPrompt systemPrompt =
+                    SystemPrompt.builder().id(1L).content("You are a helpful assistant.").build();
+            when(systemPromptRepository.findById(1L)).thenReturn(Optional.of(systemPrompt));
+
+            GenerationResponse response =
+                    GenerationResponse.builder()
+                            .response("Test response")
+                            .model("llama3:8b")
+                            .durationMs(1000L)
+                            .build();
+            when(ollamaService.generate(any(GenerationRequest.class))).thenReturn(response);
+
+            ExperimentRun result =
+                    experimentExecutorService.executeSingleRun(experiment, runConfig, config);
+
+            assertNotNull(result);
+            verify(systemPromptRepository).findById(1L);
+
+            ArgumentCaptor<GenerationRequest> requestCaptor =
+                    ArgumentCaptor.forClass(GenerationRequest.class);
+            verify(ollamaService).generate(requestCaptor.capture());
+            assertEquals(
+                    "You are a helpful assistant.", requestCaptor.getValue().getSystemPrompt());
+        }
+
+        @Test
+        @DisplayName("should handle missing system prompt gracefully")
+        void shouldHandleMissingSystemPrompt() throws Exception {
+            Experiment experiment = createExperimentWithTemplate(1L, ExperimentStatus.RUNNING);
+            ExperimentConfig config = createConfigWithSystemPrompt();
+            ExperimentRunConfig runConfig =
+                    ExperimentRunConfig.builder()
+                            .model("llama3:8b")
+                            .embeddingModel(null)
+                            .iteration(1)
+                            .build();
+
+            ExperimentRun savedRun = createExperimentRun(1L, experiment);
+            when(experimentRunRepository.save(any(ExperimentRun.class))).thenReturn(savedRun);
+            when(systemPromptRepository.findById(1L)).thenReturn(Optional.empty());
+
+            GenerationResponse response =
+                    GenerationResponse.builder()
+                            .response("Test response")
+                            .model("llama3:8b")
+                            .durationMs(1000L)
+                            .build();
+            when(ollamaService.generate(any(GenerationRequest.class))).thenReturn(response);
+
+            ExperimentRun result =
+                    experimentExecutorService.executeSingleRun(experiment, runConfig, config);
+
+            assertNotNull(result);
+            ArgumentCaptor<GenerationRequest> requestCaptor =
+                    ArgumentCaptor.forClass(GenerationRequest.class);
+            verify(ollamaService).generate(requestCaptor.capture());
+            assertNull(requestCaptor.getValue().getSystemPrompt());
+        }
+
+        @Test
+        @DisplayName("should substitute variable values in prompt")
+        void shouldSubstituteVariableValues() throws Exception {
+            TaskTemplate template =
+                    TaskTemplate.builder()
+                            .id(1L)
+                            .name("Test Template")
+                            .promptTemplate("Review this {{language}} code: {{code}}")
+                            .build();
+            Experiment experiment = createExperimentWithCustomTemplate(1L, template);
+            ExperimentConfig config = createConfigWithVariables();
+            ExperimentRunConfig runConfig =
+                    ExperimentRunConfig.builder()
+                            .model("llama3:8b")
+                            .embeddingModel(null)
+                            .iteration(1)
+                            .build();
+
+            ExperimentRun savedRun = createExperimentRun(1L, experiment);
+            when(experimentRunRepository.save(any(ExperimentRun.class))).thenReturn(savedRun);
+
+            GenerationResponse response =
+                    GenerationResponse.builder()
+                            .response("Code looks good")
+                            .model("llama3:8b")
+                            .durationMs(1000L)
+                            .build();
+            when(ollamaService.generate(any(GenerationRequest.class))).thenReturn(response);
+
+            ExperimentRun result =
+                    experimentExecutorService.executeSingleRun(experiment, runConfig, config);
+
+            assertNotNull(result);
+            ArgumentCaptor<GenerationRequest> requestCaptor =
+                    ArgumentCaptor.forClass(GenerationRequest.class);
+            verify(ollamaService).generate(requestCaptor.capture());
+            String prompt = requestCaptor.getValue().getPrompt();
+            assertTrue(prompt.contains("JavaScript"));
+            assertTrue(prompt.contains("function test() {}"));
+        }
+
+        @Test
+        @DisplayName("should execute run with null hyperparameters")
+        void shouldExecuteRunWithNullHyperparameters() throws Exception {
+            Experiment experiment = createExperimentWithTemplate(1L, ExperimentStatus.RUNNING);
+            ExperimentConfig config = createConfigWithNullHyperparameters();
+            ExperimentRunConfig runConfig =
+                    ExperimentRunConfig.builder()
+                            .model("llama3:8b")
+                            .embeddingModel(null)
+                            .iteration(1)
+                            .build();
+
+            ExperimentRun savedRun = createExperimentRun(1L, experiment);
+            when(experimentRunRepository.save(any(ExperimentRun.class))).thenReturn(savedRun);
+
+            GenerationResponse response =
+                    GenerationResponse.builder()
+                            .response("Test response")
+                            .model("llama3:8b")
+                            .durationMs(1000L)
+                            .build();
+            when(ollamaService.generate(any(GenerationRequest.class))).thenReturn(response);
+
+            ExperimentRun result =
+                    experimentExecutorService.executeSingleRun(experiment, runConfig, config);
+
+            assertNotNull(result);
+            ArgumentCaptor<GenerationRequest> requestCaptor =
+                    ArgumentCaptor.forClass(GenerationRequest.class);
+            verify(ollamaService).generate(requestCaptor.capture());
+            GenerationRequest captured = requestCaptor.getValue();
+            assertNull(captured.getTemperature());
+            assertNull(captured.getTopP());
+            assertNull(captured.getTopK());
+            assertNull(captured.getContextWindow());
+            assertNull(captured.getMaxTokens());
+        }
+    }
+
+    @Nested
+    @DisplayName("executeRuns - control flow")
+    class ExecuteRunsControlFlowTests {
+
+        @Test
+        @DisplayName("should pause execution when pause flag is set")
+        void shouldPauseExecution() throws Exception {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.DRAFT);
+            String configJson = objectMapper.writeValueAsString(createConfigWithMultipleModels());
+            experiment.setConfig(configJson);
+            experiment.setTaskTemplate(createTaskTemplate());
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+            when(experimentRepository.save(any(Experiment.class))).thenReturn(experiment);
+
+            ExperimentRun savedRun = createExperimentRun(1L, experiment);
+            when(experimentRunRepository.save(any(ExperimentRun.class))).thenReturn(savedRun);
+
+            GenerationResponse response =
+                    GenerationResponse.builder()
+                            .response("Test")
+                            .model("llama3:8b")
+                            .durationMs(1000L)
+                            .build();
+            when(ollamaService.generate(any(GenerationRequest.class)))
+                    .thenAnswer(
+                            invocation -> {
+                                experimentExecutorService.pauseExperiment(1L);
+                                return response;
+                            });
+
+            experimentExecutorService.startExperiment(1L);
+
+            Thread.sleep(1000);
+
+            ArgumentCaptor<Experiment> captor = ArgumentCaptor.forClass(Experiment.class);
+            verify(experimentRepository, atLeast(2)).save(captor.capture());
+
+            List<Experiment> savedExperiments = captor.getAllValues();
+            boolean hasPaused =
+                    savedExperiments.stream()
+                            .anyMatch(exp -> exp.getStatus() == ExperimentStatus.PAUSED);
+            assertTrue(hasPaused);
+        }
+
+        @Test
+        @DisplayName("should cancel execution when cancel flag is set")
+        void shouldCancelExecution() throws Exception {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.DRAFT);
+            String configJson = objectMapper.writeValueAsString(createConfigWithMultipleModels());
+            experiment.setConfig(configJson);
+            experiment.setTaskTemplate(createTaskTemplate());
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+            when(experimentRepository.save(any(Experiment.class))).thenReturn(experiment);
+
+            ExperimentRun savedRun = createExperimentRun(1L, experiment);
+            when(experimentRunRepository.save(any(ExperimentRun.class))).thenReturn(savedRun);
+
+            GenerationResponse response =
+                    GenerationResponse.builder()
+                            .response("Test")
+                            .model("llama3:8b")
+                            .durationMs(1000L)
+                            .build();
+            when(ollamaService.generate(any(GenerationRequest.class)))
+                    .thenAnswer(
+                            invocation -> {
+                                experimentExecutorService.cancelExperiment(1L);
+                                return response;
+                            });
+
+            experimentExecutorService.startExperiment(1L);
+
+            Thread.sleep(1000);
+
+            ArgumentCaptor<Experiment> captor = ArgumentCaptor.forClass(Experiment.class);
+            verify(experimentRepository, atLeast(2)).save(captor.capture());
+
+            List<Experiment> savedExperiments = captor.getAllValues();
+            boolean hasFailed =
+                    savedExperiments.stream()
+                            .anyMatch(exp -> exp.getStatus() == ExperimentStatus.FAILED);
+            assertTrue(hasFailed);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateExperimentStatus")
+    class UpdateExperimentStatusTests {
+
+        @Test
+        @DisplayName("should update experiment status")
+        void shouldUpdateStatus() {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.DRAFT);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+            when(experimentRepository.save(any(Experiment.class))).thenReturn(experiment);
+
+            experimentExecutorService.updateExperimentStatus(1L, ExperimentStatus.RUNNING);
+
+            ArgumentCaptor<Experiment> captor = ArgumentCaptor.forClass(Experiment.class);
+            verify(experimentRepository).save(captor.capture());
+            assertEquals(ExperimentStatus.RUNNING, captor.getValue().getStatus());
+        }
+
+        @Test
+        @DisplayName("should throw when experiment not found")
+        void shouldThrowWhenNotFound() {
+            when(experimentRepository.findById(1L)).thenReturn(Optional.empty());
+
+            assertThrows(
+                    EntityNotFoundException.class,
+                    () ->
+                            experimentExecutorService.updateExperimentStatus(
+                                    1L, ExperimentStatus.RUNNING));
+        }
+    }
+
+    @Nested
+    @DisplayName("Run Configuration Generation")
+    class RunConfigurationGenerationTests {
+
+        @Test
+        @DisplayName("should generate correct number of run configurations")
+        void shouldGenerateCorrectRunConfigs() throws Exception {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.DRAFT);
+            String configJson = objectMapper.writeValueAsString(createConfigWithMultipleModels());
+            experiment.setConfig(configJson);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            ExperimentRun savedRun = createExperimentRun(1L, experiment);
+            when(experimentRunRepository.save(any(ExperimentRun.class))).thenReturn(savedRun);
+
+            GenerationResponse response =
+                    GenerationResponse.builder()
+                            .response("Test")
+                            .model("llama3:8b")
+                            .durationMs(1000L)
+                            .build();
+            when(ollamaService.generate(any(GenerationRequest.class))).thenReturn(response);
+
+            experimentExecutorService.startExperiment(1L);
+
+            Thread.sleep(500);
+
+            verify(experimentRunRepository, atLeast(1)).save(any(ExperimentRun.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("WebSocket Message Publishing")
+    class WebSocketMessagePublishingTests {
+
+        @Test
+        @DisplayName("should publish messages to correct destination")
+        void shouldPublishToCorrectDestination() throws Exception {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.DRAFT);
+            String configJson = objectMapper.writeValueAsString(createBasicConfig());
+            experiment.setConfig(configJson);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            ExperimentRun savedRun = createExperimentRun(1L, experiment);
+            when(experimentRunRepository.save(any(ExperimentRun.class))).thenReturn(savedRun);
+
+            GenerationResponse response =
+                    GenerationResponse.builder()
+                            .response("Test")
+                            .model("llama3:8b")
+                            .durationMs(1000L)
+                            .build();
+            when(ollamaService.generate(any(GenerationRequest.class))).thenReturn(response);
+
+            experimentExecutorService.startExperiment(1L);
+
+            Thread.sleep(500);
+
+            verify(messagingTemplate, atLeastOnce())
+                    .convertAndSend(
+                            eq("/topic/experiments/1/progress"), any(WebSocketMessage.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("Config Parsing")
+    class ConfigParsingTests {
+
+        @Test
+        @DisplayName("should throw IllegalArgumentException for null config")
+        void shouldThrowForNullConfig() {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.DRAFT);
+            experiment.setConfig(null);
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> experimentExecutorService.startExperiment(1L));
+        }
+
+        @Test
+        @DisplayName("should throw IllegalArgumentException for blank config")
+        void shouldThrowForBlankConfig() {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.DRAFT);
+            experiment.setConfig("   ");
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> experimentExecutorService.startExperiment(1L));
+        }
+
+        @Test
+        @DisplayName("should throw IllegalArgumentException for invalid JSON config")
+        void shouldThrowForInvalidJson() {
+            Experiment experiment = createExperiment(1L, ExperimentStatus.DRAFT);
+            experiment.setConfig("not valid json");
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(experiment));
+
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> experimentExecutorService.startExperiment(1L));
+        }
+    }
+
+    @Nested
+    @DisplayName("ExperimentRunConfig")
+    class ExperimentRunConfigTests {
+
+        @Test
+        @DisplayName("should build run config correctly")
+        void shouldBuildRunConfig() {
+            ExperimentRunConfig config =
+                    ExperimentRunConfig.builder()
+                            .model("llama3:8b")
+                            .embeddingModel("nomic-embed-text")
+                            .iteration(3)
+                            .build();
+
+            assertEquals("llama3:8b", config.getModel());
+            assertEquals("nomic-embed-text", config.getEmbeddingModel());
+            assertEquals(3, config.getIteration());
+        }
+
+        @Test
+        @DisplayName("should allow null embedding model for non-RAG runs")
+        void shouldAllowNullEmbeddingModel() {
+            ExperimentRunConfig config =
+                    ExperimentRunConfig.builder()
+                            .model("llama3:8b")
+                            .embeddingModel(null)
+                            .iteration(1)
+                            .build();
+
+            assertEquals("llama3:8b", config.getModel());
+            assertNull(config.getEmbeddingModel());
+        }
+    }
+
+    private Experiment createExperiment(Long id, ExperimentStatus status) {
+        return Experiment.builder().id(id).name("Test Experiment").status(status).build();
+    }
+
+    private Experiment createExperimentWithTemplate(Long id, ExperimentStatus status) {
+        TaskTemplate template =
+                TaskTemplate.builder()
+                        .id(1L)
+                        .name("Test Template")
+                        .promptTemplate("{{prompt}}")
+                        .build();
+        return Experiment.builder()
+                .id(id)
+                .name("Test Experiment")
+                .status(status)
+                .taskTemplate(template)
+                .build();
+    }
+
+    private Experiment createExperimentWithCustomTemplate(Long id, TaskTemplate template) {
+        return Experiment.builder()
+                .id(id)
+                .name("Test Experiment")
+                .status(ExperimentStatus.RUNNING)
+                .taskTemplate(template)
+                .build();
+    }
+
+    private ExperimentRun createExperimentRun(Long id, Experiment experiment) {
+        return ExperimentRun.builder()
+                .id(id)
+                .experiment(experiment)
+                .modelName("llama3:8b")
+                .iteration(1)
+                .status(RunStatus.PENDING)
+                .build();
+    }
+
+    private ExperimentConfig createBasicConfig() {
+        return ExperimentConfig.builder()
+                .models(List.of("llama3:8b"))
+                .iterations(1)
+                .contextMode("NONE")
+                .hyperparameters(Hyperparameters.builder().temperature(0.7).build())
+                .build();
+    }
+
+    private ExperimentConfig createRagConfig() {
+        return ExperimentConfig.builder()
+                .models(List.of("llama3:8b"))
+                .embeddingModels(List.of("nomic-embed-text"))
+                .iterations(1)
+                .contextMode("RAG")
+                .documentId(1L)
+                .hyperparameters(Hyperparameters.builder().temperature(0.7).build())
+                .build();
+    }
+
+    private ExperimentConfig createConfigWithSystemPrompt() {
+        return ExperimentConfig.builder()
+                .models(List.of("llama3:8b"))
+                .iterations(1)
+                .contextMode("NONE")
+                .systemPromptId(1L)
+                .hyperparameters(Hyperparameters.builder().temperature(0.7).build())
+                .build();
+    }
+
+    private ExperimentConfig createConfigWithMultipleModels() {
+        return ExperimentConfig.builder()
+                .models(List.of("llama3:8b", "qwen2.5-coder:7b"))
+                .iterations(2)
+                .contextMode("NONE")
+                .hyperparameters(Hyperparameters.builder().temperature(0.7).build())
+                .build();
+    }
+
+    private ExperimentConfig createConfigWithVariables() {
+        return ExperimentConfig.builder()
+                .models(List.of("llama3:8b"))
+                .iterations(1)
+                .contextMode("NONE")
+                .hyperparameters(Hyperparameters.builder().temperature(0.7).build())
+                .variableValues(
+                        Map.of(
+                                "language", "JavaScript",
+                                "code", "function test() {}"))
+                .build();
+    }
+
+    private ExperimentConfig createConfigWithNullHyperparameters() {
+        return ExperimentConfig.builder()
+                .models(List.of("llama3:8b"))
+                .iterations(1)
+                .contextMode("NONE")
+                .hyperparameters(null)
+                .build();
+    }
+
+    private TaskTemplate createTaskTemplate() {
+        return TaskTemplate.builder()
+                .id(1L)
+                .name("Test Template")
+                .promptTemplate("{{prompt}}")
+                .build();
+    }
+}

--- a/backend/src/test/java/com/locallab/service/ExperimentServiceTest.java
+++ b/backend/src/test/java/com/locallab/service/ExperimentServiceTest.java
@@ -1,0 +1,967 @@
+package com.locallab.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.locallab.dto.ExperimentConfig;
+import com.locallab.dto.Hyperparameters;
+import com.locallab.dto.request.ExperimentRequest;
+import com.locallab.model.Experiment;
+import com.locallab.model.TaskTemplate;
+import com.locallab.model.enums.ExperimentStatus;
+import com.locallab.repository.ExperimentRepository;
+import com.locallab.repository.TaskTemplateRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+
+/**
+ * Unit tests for {@link ExperimentService}.
+ *
+ * <p>Uses Mockito to mock the {@link ExperimentRepository} and {@link TaskTemplateRepository}
+ * dependencies. Tests cover all CRUD operations, status management, run calculation, configuration
+ * validation, and error handling scenarios.
+ *
+ * @see ExperimentService
+ * @see ExperimentRepository
+ */
+@ExtendWith(MockitoExtension.class)
+class ExperimentServiceTest {
+
+    @Mock private ExperimentRepository experimentRepository;
+
+    @Mock private TaskTemplateRepository taskTemplateRepository;
+
+    private ObjectMapper objectMapper;
+
+    @InjectMocks private ExperimentService experimentService;
+
+    private Experiment draftExperiment;
+    private Experiment runningExperiment;
+    private Experiment completedExperiment;
+    private TaskTemplate taskTemplate;
+    private ExperimentRequest createRequest;
+    private ExperimentConfig validConfig;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        experimentService =
+                new ExperimentService(experimentRepository, taskTemplateRepository, objectMapper);
+
+        taskTemplate =
+                TaskTemplate.builder()
+                        .id(1L)
+                        .name("Code Review Task")
+                        .promptTemplate("Review the following code: {{code}}")
+                        .createdAt(LocalDateTime.now())
+                        .build();
+
+        String configJson =
+                "{\"models\":[\"qwen2.5-coder:7b\",\"codellama:7b\"],"
+                        + "\"iterations\":3,"
+                        + "\"contextMode\":\"NONE\","
+                        + "\"hyperparameters\":{\"temperature\":0.7}}";
+
+        draftExperiment =
+                Experiment.builder()
+                        .id(1L)
+                        .name("Draft Experiment")
+                        .taskTemplate(taskTemplate)
+                        .status(ExperimentStatus.DRAFT)
+                        .config(configJson)
+                        .createdAt(LocalDateTime.now())
+                        .build();
+
+        runningExperiment =
+                Experiment.builder()
+                        .id(2L)
+                        .name("Running Experiment")
+                        .taskTemplate(taskTemplate)
+                        .status(ExperimentStatus.RUNNING)
+                        .config(configJson)
+                        .createdAt(LocalDateTime.now())
+                        .build();
+
+        completedExperiment =
+                Experiment.builder()
+                        .id(3L)
+                        .name("Completed Experiment")
+                        .taskTemplate(taskTemplate)
+                        .status(ExperimentStatus.COMPLETED)
+                        .config(configJson)
+                        .createdAt(LocalDateTime.now())
+                        .build();
+
+        validConfig =
+                ExperimentConfig.builder()
+                        .models(Arrays.asList("qwen2.5-coder:7b", "codellama:7b"))
+                        .iterations(3)
+                        .contextMode("NONE")
+                        .hyperparameters(Hyperparameters.builder().temperature(0.7).build())
+                        .build();
+
+        createRequest =
+                ExperimentRequest.builder()
+                        .name("New Experiment")
+                        .taskTemplateId(1L)
+                        .config(validConfig)
+                        .build();
+    }
+
+    @Nested
+    @DisplayName("findAll Tests")
+    class FindAllTests {
+
+        @Test
+        @DisplayName("Should return all experiments ordered by creation date")
+        void shouldReturnAllExperimentsOrderedByCreationDate() {
+            when(experimentRepository.findAllByOrderByCreatedAtDesc())
+                    .thenReturn(Arrays.asList(draftExperiment, runningExperiment));
+
+            List<Experiment> results = experimentService.findAll();
+
+            assertEquals(2, results.size());
+            verify(experimentRepository).findAllByOrderByCreatedAtDesc();
+        }
+
+        @Test
+        @DisplayName("Should return empty list when no experiments exist")
+        void shouldReturnEmptyListWhenNoExperimentsExist() {
+            when(experimentRepository.findAllByOrderByCreatedAtDesc())
+                    .thenReturn(Collections.emptyList());
+
+            List<Experiment> results = experimentService.findAll();
+
+            assertTrue(results.isEmpty());
+            verify(experimentRepository).findAllByOrderByCreatedAtDesc();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByStatus Tests")
+    class FindByStatusTests {
+
+        @Test
+        @DisplayName("Should return experiments with specified status")
+        void shouldReturnExperimentsWithSpecifiedStatus() {
+            when(experimentRepository.findByStatusOrderByCreatedAtDesc(ExperimentStatus.DRAFT))
+                    .thenReturn(Collections.singletonList(draftExperiment));
+
+            List<Experiment> results = experimentService.findByStatus(ExperimentStatus.DRAFT);
+
+            assertEquals(1, results.size());
+            assertEquals(ExperimentStatus.DRAFT, results.get(0).getStatus());
+            verify(experimentRepository).findByStatusOrderByCreatedAtDesc(ExperimentStatus.DRAFT);
+        }
+
+        @Test
+        @DisplayName("Should return empty list when no experiments match status")
+        void shouldReturnEmptyListWhenNoExperimentsMatchStatus() {
+            when(experimentRepository.findByStatusOrderByCreatedAtDesc(ExperimentStatus.PAUSED))
+                    .thenReturn(Collections.emptyList());
+
+            List<Experiment> results = experimentService.findByStatus(ExperimentStatus.PAUSED);
+
+            assertTrue(results.isEmpty());
+            verify(experimentRepository).findByStatusOrderByCreatedAtDesc(ExperimentStatus.PAUSED);
+        }
+    }
+
+    @Nested
+    @DisplayName("findById Tests")
+    class FindByIdTests {
+
+        @Test
+        @DisplayName("Should return experiment when found")
+        void shouldReturnExperimentWhenFound() {
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(draftExperiment));
+
+            Experiment result = experimentService.findById(1L);
+
+            assertNotNull(result);
+            assertEquals("Draft Experiment", result.getName());
+            verify(experimentRepository).findById(1L);
+        }
+
+        @Test
+        @DisplayName("Should throw EntityNotFoundException when not found")
+        void shouldThrowEntityNotFoundExceptionWhenNotFound() {
+            when(experimentRepository.findById(999L)).thenReturn(Optional.empty());
+
+            EntityNotFoundException exception =
+                    assertThrows(
+                            EntityNotFoundException.class, () -> experimentService.findById(999L));
+
+            assertEquals("Experiment not found: 999", exception.getMessage());
+            verify(experimentRepository).findById(999L);
+        }
+    }
+
+    @Nested
+    @DisplayName("create Tests")
+    class CreateTests {
+
+        @Test
+        @DisplayName("Should create experiment with all fields")
+        void shouldCreateExperimentWithAllFields() {
+            when(taskTemplateRepository.findById(1L)).thenReturn(Optional.of(taskTemplate));
+            when(experimentRepository.save(any(Experiment.class)))
+                    .thenAnswer(
+                            invocation -> {
+                                Experiment exp = invocation.getArgument(0);
+                                exp.setId(10L);
+                                return exp;
+                            });
+
+            Experiment result = experimentService.create(createRequest);
+
+            assertNotNull(result);
+            assertEquals(10L, result.getId());
+            assertEquals("New Experiment", result.getName());
+            assertEquals(ExperimentStatus.DRAFT, result.getStatus());
+            assertEquals(taskTemplate, result.getTaskTemplate());
+
+            ArgumentCaptor<Experiment> captor = ArgumentCaptor.forClass(Experiment.class);
+            verify(experimentRepository).save(captor.capture());
+
+            Experiment captured = captor.getValue();
+            assertEquals("New Experiment", captured.getName());
+            assertEquals(ExperimentStatus.DRAFT, captured.getStatus());
+        }
+
+        @Test
+        @DisplayName("Should create experiment without task template")
+        void shouldCreateExperimentWithoutTaskTemplate() {
+            ExperimentRequest requestWithoutTemplate =
+                    ExperimentRequest.builder()
+                            .name("No Template Experiment")
+                            .config(validConfig)
+                            .build();
+
+            when(experimentRepository.save(any(Experiment.class)))
+                    .thenAnswer(
+                            invocation -> {
+                                Experiment exp = invocation.getArgument(0);
+                                exp.setId(11L);
+                                return exp;
+                            });
+
+            Experiment result = experimentService.create(requestWithoutTemplate);
+
+            assertNotNull(result);
+            assertEquals("No Template Experiment", result.getName());
+            assertNull(result.getTaskTemplate());
+
+            verify(taskTemplateRepository, never()).findById(any());
+        }
+
+        @Test
+        @DisplayName("Should throw EntityNotFoundException when task template not found")
+        void shouldThrowEntityNotFoundExceptionWhenTaskTemplateNotFound() {
+            when(taskTemplateRepository.findById(999L)).thenReturn(Optional.empty());
+
+            ExperimentRequest requestWithInvalidTemplate =
+                    ExperimentRequest.builder()
+                            .name("Invalid Template Experiment")
+                            .taskTemplateId(999L)
+                            .config(validConfig)
+                            .build();
+
+            EntityNotFoundException exception =
+                    assertThrows(
+                            EntityNotFoundException.class,
+                            () -> experimentService.create(requestWithInvalidTemplate));
+
+            assertEquals("Task template not found: 999", exception.getMessage());
+            verify(experimentRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when no models specified")
+        void shouldThrowIllegalArgumentExceptionWhenNoModelsSpecified() {
+            ExperimentConfig invalidConfig =
+                    ExperimentConfig.builder()
+                            .models(Collections.emptyList())
+                            .iterations(3)
+                            .contextMode("NONE")
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            ExperimentRequest invalidRequest =
+                    ExperimentRequest.builder()
+                            .name("Invalid Experiment")
+                            .config(invalidConfig)
+                            .build();
+
+            IllegalArgumentException exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> experimentService.create(invalidRequest));
+
+            assertEquals("At least one model must be selected", exception.getMessage());
+            verify(experimentRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when models is null")
+        void shouldThrowIllegalArgumentExceptionWhenModelsIsNull() {
+            ExperimentConfig invalidConfig =
+                    ExperimentConfig.builder()
+                            .models(null)
+                            .iterations(3)
+                            .contextMode("NONE")
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            ExperimentRequest invalidRequest =
+                    ExperimentRequest.builder()
+                            .name("Invalid Experiment")
+                            .config(invalidConfig)
+                            .build();
+
+            IllegalArgumentException exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> experimentService.create(invalidRequest));
+
+            assertEquals("At least one model must be selected", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when iterations less than 1")
+        void shouldThrowIllegalArgumentExceptionWhenIterationsLessThan1() {
+            ExperimentConfig invalidConfig =
+                    ExperimentConfig.builder()
+                            .models(Arrays.asList("model1"))
+                            .iterations(0)
+                            .contextMode("NONE")
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            ExperimentRequest invalidRequest =
+                    ExperimentRequest.builder()
+                            .name("Invalid Experiment")
+                            .config(invalidConfig)
+                            .build();
+
+            IllegalArgumentException exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> experimentService.create(invalidRequest));
+
+            assertEquals("Iterations must be at least 1", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when RAG mode without embedding models")
+        void shouldThrowIllegalArgumentExceptionWhenRagModeWithoutEmbeddingModels() {
+            ExperimentConfig ragConfig =
+                    ExperimentConfig.builder()
+                            .models(Arrays.asList("model1"))
+                            .iterations(3)
+                            .contextMode("RAG")
+                            .documentId(1L)
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            ExperimentRequest ragRequest =
+                    ExperimentRequest.builder().name("RAG Experiment").config(ragConfig).build();
+
+            IllegalArgumentException exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> experimentService.create(ragRequest));
+
+            assertEquals(
+                    "Embedding models must be specified for RAG context mode",
+                    exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException when RAG mode without document ID")
+        void shouldThrowIllegalArgumentExceptionWhenRagModeWithoutDocumentId() {
+            ExperimentConfig ragConfig =
+                    ExperimentConfig.builder()
+                            .models(Arrays.asList("model1"))
+                            .embeddingModels(Arrays.asList("embed1"))
+                            .iterations(3)
+                            .contextMode("RAG")
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            ExperimentRequest ragRequest =
+                    ExperimentRequest.builder().name("RAG Experiment").config(ragConfig).build();
+
+            IllegalArgumentException exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> experimentService.create(ragRequest));
+
+            assertEquals(
+                    "Document ID must be specified for RAG context mode", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should create experiment with valid RAG configuration")
+        void shouldCreateExperimentWithValidRagConfiguration() {
+            ExperimentConfig ragConfig =
+                    ExperimentConfig.builder()
+                            .models(Arrays.asList("model1"))
+                            .embeddingModels(Arrays.asList("embed1", "embed2"))
+                            .iterations(2)
+                            .contextMode("RAG")
+                            .documentId(1L)
+                            .hyperparameters(Hyperparameters.builder().temperature(0.5).build())
+                            .build();
+
+            ExperimentRequest ragRequest =
+                    ExperimentRequest.builder()
+                            .name("Valid RAG Experiment")
+                            .config(ragConfig)
+                            .build();
+
+            when(experimentRepository.save(any(Experiment.class)))
+                    .thenAnswer(
+                            invocation -> {
+                                Experiment exp = invocation.getArgument(0);
+                                exp.setId(12L);
+                                return exp;
+                            });
+
+            Experiment result = experimentService.create(ragRequest);
+
+            assertNotNull(result);
+            assertEquals("Valid RAG Experiment", result.getName());
+        }
+    }
+
+    @Nested
+    @DisplayName("update Tests")
+    class UpdateTests {
+
+        @Test
+        @DisplayName("Should update draft experiment successfully")
+        void shouldUpdateDraftExperimentSuccessfully() {
+            ExperimentRequest updateRequest =
+                    ExperimentRequest.builder()
+                            .name("Updated Experiment")
+                            .taskTemplateId(1L)
+                            .config(validConfig)
+                            .build();
+
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(draftExperiment));
+            when(taskTemplateRepository.findById(1L)).thenReturn(Optional.of(taskTemplate));
+            when(experimentRepository.save(any(Experiment.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            Experiment result = experimentService.update(1L, updateRequest);
+
+            assertNotNull(result);
+            assertEquals("Updated Experiment", result.getName());
+            verify(experimentRepository).save(any(Experiment.class));
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalStateException when updating running experiment")
+        void shouldThrowIllegalStateExceptionWhenUpdatingRunningExperiment() {
+            when(experimentRepository.findById(2L)).thenReturn(Optional.of(runningExperiment));
+
+            IllegalStateException exception =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> experimentService.update(2L, createRequest));
+
+            assertEquals("Cannot update experiment with status: RUNNING", exception.getMessage());
+            verify(experimentRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalStateException when updating completed experiment")
+        void shouldThrowIllegalStateExceptionWhenUpdatingCompletedExperiment() {
+            when(experimentRepository.findById(3L)).thenReturn(Optional.of(completedExperiment));
+
+            IllegalStateException exception =
+                    assertThrows(
+                            IllegalStateException.class,
+                            () -> experimentService.update(3L, createRequest));
+
+            assertEquals("Cannot update experiment with status: COMPLETED", exception.getMessage());
+            verify(experimentRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should throw EntityNotFoundException when updating non-existent experiment")
+        void shouldThrowEntityNotFoundExceptionWhenUpdatingNonExistentExperiment() {
+            when(experimentRepository.findById(999L)).thenReturn(Optional.empty());
+
+            EntityNotFoundException exception =
+                    assertThrows(
+                            EntityNotFoundException.class,
+                            () -> experimentService.update(999L, createRequest));
+
+            assertEquals("Experiment not found: 999", exception.getMessage());
+            verify(experimentRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("Should update experiment to remove task template")
+        void shouldUpdateExperimentToRemoveTaskTemplate() {
+            ExperimentRequest updateRequest =
+                    ExperimentRequest.builder()
+                            .name("Updated Without Template")
+                            .taskTemplateId(null)
+                            .config(validConfig)
+                            .build();
+
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(draftExperiment));
+            when(experimentRepository.save(any(Experiment.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            Experiment result = experimentService.update(1L, updateRequest);
+
+            assertNotNull(result);
+            assertNull(result.getTaskTemplate());
+            verify(taskTemplateRepository, never()).findById(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("delete Tests")
+    class DeleteTests {
+
+        @Test
+        @DisplayName("Should delete draft experiment successfully")
+        void shouldDeleteDraftExperimentSuccessfully() {
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(draftExperiment));
+
+            experimentService.delete(1L);
+
+            verify(experimentRepository).delete(draftExperiment);
+        }
+
+        @Test
+        @DisplayName("Should delete completed experiment successfully")
+        void shouldDeleteCompletedExperimentSuccessfully() {
+            when(experimentRepository.findById(3L)).thenReturn(Optional.of(completedExperiment));
+
+            experimentService.delete(3L);
+
+            verify(experimentRepository).delete(completedExperiment);
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalStateException when deleting running experiment")
+        void shouldThrowIllegalStateExceptionWhenDeletingRunningExperiment() {
+            when(experimentRepository.findById(2L)).thenReturn(Optional.of(runningExperiment));
+
+            IllegalStateException exception =
+                    assertThrows(IllegalStateException.class, () -> experimentService.delete(2L));
+
+            assertEquals("Cannot delete a running experiment", exception.getMessage());
+            verify(experimentRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("Should throw EntityNotFoundException when deleting non-existent experiment")
+        void shouldThrowEntityNotFoundExceptionWhenDeletingNonExistentExperiment() {
+            when(experimentRepository.findById(999L)).thenReturn(Optional.empty());
+
+            EntityNotFoundException exception =
+                    assertThrows(
+                            EntityNotFoundException.class, () -> experimentService.delete(999L));
+
+            assertEquals("Experiment not found: 999", exception.getMessage());
+            verify(experimentRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("Should allow deleting paused experiment")
+        void shouldAllowDeletingPausedExperiment() {
+            Experiment pausedExperiment =
+                    Experiment.builder()
+                            .id(4L)
+                            .name("Paused Experiment")
+                            .status(ExperimentStatus.PAUSED)
+                            .build();
+
+            when(experimentRepository.findById(4L)).thenReturn(Optional.of(pausedExperiment));
+
+            experimentService.delete(4L);
+
+            verify(experimentRepository).delete(pausedExperiment);
+        }
+
+        @Test
+        @DisplayName("Should allow deleting failed experiment")
+        void shouldAllowDeletingFailedExperiment() {
+            Experiment failedExperiment =
+                    Experiment.builder()
+                            .id(5L)
+                            .name("Failed Experiment")
+                            .status(ExperimentStatus.FAILED)
+                            .build();
+
+            when(experimentRepository.findById(5L)).thenReturn(Optional.of(failedExperiment));
+
+            experimentService.delete(5L);
+
+            verify(experimentRepository).delete(failedExperiment);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStatus Tests")
+    class UpdateStatusTests {
+
+        @Test
+        @DisplayName("Should update status to RUNNING")
+        void shouldUpdateStatusToRunning() {
+            when(experimentRepository.findById(1L)).thenReturn(Optional.of(draftExperiment));
+            when(experimentRepository.save(any(Experiment.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            experimentService.updateStatus(1L, ExperimentStatus.RUNNING);
+
+            ArgumentCaptor<Experiment> captor = ArgumentCaptor.forClass(Experiment.class);
+            verify(experimentRepository).save(captor.capture());
+            assertEquals(ExperimentStatus.RUNNING, captor.getValue().getStatus());
+        }
+
+        @Test
+        @DisplayName("Should update status to COMPLETED")
+        void shouldUpdateStatusToCompleted() {
+            when(experimentRepository.findById(2L)).thenReturn(Optional.of(runningExperiment));
+            when(experimentRepository.save(any(Experiment.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            experimentService.updateStatus(2L, ExperimentStatus.COMPLETED);
+
+            ArgumentCaptor<Experiment> captor = ArgumentCaptor.forClass(Experiment.class);
+            verify(experimentRepository).save(captor.capture());
+            assertEquals(ExperimentStatus.COMPLETED, captor.getValue().getStatus());
+        }
+
+        @Test
+        @DisplayName("Should update status to PAUSED")
+        void shouldUpdateStatusToPaused() {
+            when(experimentRepository.findById(2L)).thenReturn(Optional.of(runningExperiment));
+            when(experimentRepository.save(any(Experiment.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            experimentService.updateStatus(2L, ExperimentStatus.PAUSED);
+
+            ArgumentCaptor<Experiment> captor = ArgumentCaptor.forClass(Experiment.class);
+            verify(experimentRepository).save(captor.capture());
+            assertEquals(ExperimentStatus.PAUSED, captor.getValue().getStatus());
+        }
+
+        @Test
+        @DisplayName("Should update status to FAILED")
+        void shouldUpdateStatusToFailed() {
+            when(experimentRepository.findById(2L)).thenReturn(Optional.of(runningExperiment));
+            when(experimentRepository.save(any(Experiment.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            experimentService.updateStatus(2L, ExperimentStatus.FAILED);
+
+            ArgumentCaptor<Experiment> captor = ArgumentCaptor.forClass(Experiment.class);
+            verify(experimentRepository).save(captor.capture());
+            assertEquals(ExperimentStatus.FAILED, captor.getValue().getStatus());
+        }
+
+        @Test
+        @DisplayName("Should throw EntityNotFoundException when experiment not found")
+        void shouldThrowEntityNotFoundExceptionWhenExperimentNotFound() {
+            when(experimentRepository.findById(999L)).thenReturn(Optional.empty());
+
+            EntityNotFoundException exception =
+                    assertThrows(
+                            EntityNotFoundException.class,
+                            () -> experimentService.updateStatus(999L, ExperimentStatus.RUNNING));
+
+            assertEquals("Experiment not found: 999", exception.getMessage());
+            verify(experimentRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("calculateTotalRuns Tests")
+    class CalculateTotalRunsTests {
+
+        @Test
+        @DisplayName("Should calculate runs for single model without embeddings")
+        void shouldCalculateRunsForSingleModelWithoutEmbeddings() {
+            ExperimentConfig config =
+                    ExperimentConfig.builder()
+                            .models(Arrays.asList("model1"))
+                            .iterations(5)
+                            .contextMode("NONE")
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            int totalRuns = experimentService.calculateTotalRuns(config);
+
+            assertEquals(5, totalRuns); // 1 model × 1 embedding × 5 iterations
+        }
+
+        @Test
+        @DisplayName("Should calculate runs for multiple models without embeddings")
+        void shouldCalculateRunsForMultipleModelsWithoutEmbeddings() {
+            ExperimentConfig config =
+                    ExperimentConfig.builder()
+                            .models(Arrays.asList("model1", "model2", "model3"))
+                            .iterations(3)
+                            .contextMode("NONE")
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            int totalRuns = experimentService.calculateTotalRuns(config);
+
+            assertEquals(9, totalRuns); // 3 models × 1 embedding × 3 iterations
+        }
+
+        @Test
+        @DisplayName("Should calculate runs with embedding models")
+        void shouldCalculateRunsWithEmbeddingModels() {
+            ExperimentConfig config =
+                    ExperimentConfig.builder()
+                            .models(Arrays.asList("model1", "model2"))
+                            .embeddingModels(Arrays.asList("embed1", "embed2", "embed3"))
+                            .iterations(2)
+                            .contextMode("RAG")
+                            .documentId(1L)
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            int totalRuns = experimentService.calculateTotalRuns(config);
+
+            assertEquals(12, totalRuns); // 2 models × 3 embeddings × 2 iterations
+        }
+
+        @Test
+        @DisplayName("Should treat empty embedding list as non-RAG mode")
+        void shouldTreatEmptyEmbeddingListAsNonRagMode() {
+            ExperimentConfig config =
+                    ExperimentConfig.builder()
+                            .models(Arrays.asList("model1", "model2"))
+                            .embeddingModels(Collections.emptyList())
+                            .iterations(4)
+                            .contextMode("NONE")
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            int totalRuns = experimentService.calculateTotalRuns(config);
+
+            assertEquals(8, totalRuns); // 2 models × 1 embedding × 4 iterations
+        }
+
+        @Test
+        @DisplayName("Should treat null embedding list as non-RAG mode")
+        void shouldTreatNullEmbeddingListAsNonRagMode() {
+            ExperimentConfig config =
+                    ExperimentConfig.builder()
+                            .models(Arrays.asList("model1"))
+                            .embeddingModels(null)
+                            .iterations(10)
+                            .contextMode("NONE")
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            int totalRuns = experimentService.calculateTotalRuns(config);
+
+            assertEquals(10, totalRuns); // 1 model × 1 embedding × 10 iterations
+        }
+
+        @Test
+        @DisplayName("Should default to 1 iteration when null")
+        void shouldDefaultTo1IterationWhenNull() {
+            ExperimentConfig config =
+                    ExperimentConfig.builder()
+                            .models(Arrays.asList("model1", "model2"))
+                            .iterations(null)
+                            .contextMode("NONE")
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            int totalRuns = experimentService.calculateTotalRuns(config);
+
+            assertEquals(2, totalRuns); // 2 models × 1 embedding × 1 iteration
+        }
+
+        @Test
+        @DisplayName("Should return 0 when no models")
+        void shouldReturn0WhenNoModels() {
+            ExperimentConfig config =
+                    ExperimentConfig.builder()
+                            .models(Collections.emptyList())
+                            .iterations(5)
+                            .contextMode("NONE")
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            int totalRuns = experimentService.calculateTotalRuns(config);
+
+            assertEquals(0, totalRuns); // 0 models × 1 embedding × 5 iterations
+        }
+
+        @Test
+        @DisplayName("Should return 0 when models is null")
+        void shouldReturn0WhenModelsIsNull() {
+            ExperimentConfig config =
+                    ExperimentConfig.builder()
+                            .models(null)
+                            .iterations(5)
+                            .contextMode("NONE")
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            int totalRuns = experimentService.calculateTotalRuns(config);
+
+            assertEquals(0, totalRuns); // 0 models × 1 embedding × 5 iterations
+        }
+
+        @Test
+        @DisplayName("Should calculate complex configuration correctly")
+        void shouldCalculateComplexConfigurationCorrectly() {
+            ExperimentConfig config =
+                    ExperimentConfig.builder()
+                            .models(
+                                    Arrays.asList(
+                                            "qwen2.5-coder:7b",
+                                            "codellama:7b",
+                                            "deepseek-coder:6.7b"))
+                            .embeddingModels(Arrays.asList("nomic-embed-text", "mxbai-embed-large"))
+                            .iterations(3)
+                            .contextMode("RAG")
+                            .documentId(1L)
+                            .hyperparameters(Hyperparameters.builder().build())
+                            .build();
+
+            int totalRuns = experimentService.calculateTotalRuns(config);
+
+            assertEquals(18, totalRuns); // 3 models × 2 embeddings × 3 iterations
+        }
+    }
+
+    @Nested
+    @DisplayName("parseConfig Tests")
+    class ParseConfigTests {
+
+        @Test
+        @DisplayName("Should parse valid JSON config")
+        void shouldParseValidJsonConfig() {
+            String json =
+                    "{\"models\":[\"model1\"],\"iterations\":3,\"contextMode\":\"NONE\","
+                            + "\"hyperparameters\":{\"temperature\":0.7}}";
+
+            ExperimentConfig config = experimentService.parseConfig(json);
+
+            assertNotNull(config);
+            assertEquals(1, config.getModels().size());
+            assertEquals("model1", config.getModels().get(0));
+            assertEquals(3, config.getIterations());
+            assertEquals("NONE", config.getContextMode());
+            assertEquals(0.7, config.getHyperparameters().getTemperature());
+        }
+
+        @Test
+        @DisplayName("Should return null for null JSON")
+        void shouldReturnNullForNullJson() {
+            ExperimentConfig config = experimentService.parseConfig(null);
+
+            assertNull(config);
+        }
+
+        @Test
+        @DisplayName("Should return null for empty JSON")
+        void shouldReturnNullForEmptyJson() {
+            ExperimentConfig config = experimentService.parseConfig("");
+
+            assertNull(config);
+        }
+
+        @Test
+        @DisplayName("Should throw IllegalArgumentException for invalid JSON")
+        void shouldThrowIllegalArgumentExceptionForInvalidJson() {
+            String invalidJson = "not valid json";
+
+            IllegalArgumentException exception =
+                    assertThrows(
+                            IllegalArgumentException.class,
+                            () -> experimentService.parseConfig(invalidJson));
+
+            assertEquals("Invalid experiment configuration JSON", exception.getMessage());
+        }
+
+        @Test
+        @DisplayName("Should parse config with all fields")
+        void shouldParseConfigWithAllFields() {
+            String json =
+                    "{\"models\":[\"model1\",\"model2\"],"
+                            + "\"embeddingModels\":[\"embed1\"],"
+                            + "\"iterations\":5,"
+                            + "\"contextMode\":\"RAG\","
+                            + "\"documentId\":1,"
+                            + "\"systemPromptId\":2,"
+                            + "\"hyperparameters\":{\"temperature\":0.8,\"topP\":0.9,\"topK\":50},"
+                            + "\"variableValues\":{\"code\":\"test code\"}}";
+
+            ExperimentConfig config = experimentService.parseConfig(json);
+
+            assertNotNull(config);
+            assertEquals(2, config.getModels().size());
+            assertEquals(1, config.getEmbeddingModels().size());
+            assertEquals(5, config.getIterations());
+            assertEquals("RAG", config.getContextMode());
+            assertEquals(1L, config.getDocumentId());
+            assertEquals(2L, config.getSystemPromptId());
+            assertEquals(0.8, config.getHyperparameters().getTemperature());
+            assertEquals(0.9, config.getHyperparameters().getTopP());
+            assertEquals(50, config.getHyperparameters().getTopK());
+            assertEquals("test code", config.getVariableValues().get("code"));
+        }
+
+        @Test
+        @DisplayName("Should handle variable values map")
+        void shouldHandleVariableValuesMap() {
+            String json =
+                    "{\"models\":[\"model1\"],\"iterations\":1,\"contextMode\":\"NONE\","
+                            + "\"hyperparameters\":{},"
+                            + "\"variableValues\":{\"key1\":\"value1\",\"key2\":\"value2\"}}";
+
+            ExperimentConfig config = experimentService.parseConfig(json);
+
+            assertNotNull(config);
+            Map<String, String> variables = config.getVariableValues();
+            assertNotNull(variables);
+            assertEquals(2, variables.size());
+            assertEquals("value1", variables.get("key1"));
+            assertEquals("value2", variables.get("key2"));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the final three services to complete the **Service Layer** (Parent Issue #5):

### Services Implemented

- **ExperimentService**: CRUD for experiments, configuration validation, and run matrix calculation.
- **ExperimentExecutorService**: Asynchronous execution engine with pause/resume/cancel support and WebSocket progress updates.
- **AnalyticsService**: Metric aggregation, success rate calculation, and leaderboard generation.

### Supporting Changes

- **New DTOs**: `ExperimentConfig`, `ExperimentProgress`, `LeaderboardData`, `ModelMetrics`, `WebSocketMessage`, etc.
- **Config Classes**: `AsyncConfig`, `WebSocketConfig`
- **Tests**: Full unit test coverage for all three services.
- **pom.xml**: Added JaCoCo exclusion for `LocalLabApplication` class.

### Issue Tracking

Closes #47
Closes #48
Closes #49

_Completes Parent Issue #5 (Service Layer)_